### PR TITLE
speed up scrollbox anim, turn off default

### DIFF
--- a/src/behaviors/ScrollBox/ScrollBox.js
+++ b/src/behaviors/ScrollBox/ScrollBox.js
@@ -21,7 +21,7 @@ const ScrollBox = styled.div.withConfig({ displayName: 'ScrollBox' })`
   ${({ animateIn }) => {
     if (animateIn) {
       return css`
-        animation: ${appearAnimation} 0.5s ease;
+        animation: ${appearAnimation} 0.3s ease;
       `;
     }
 
@@ -43,16 +43,16 @@ const ScrollBox = styled.div.withConfig({ displayName: 'ScrollBox' })`
 `;
 
 ScrollBox.defaultProps = {
-  animateIn: true,
+  animateIn: false,
 };
 
 ScrollBox.usage = `
 # ScrollBox
 
-ScrollBox lays out content vertically via flexbox, and allows its content to scroll vertically. It also includes a little animation as content appears. You can turn this off with \`animateIn\`.
+ScrollBox lays out content vertically via flexbox, and allows its content to scroll vertically. It also includes an optional little animation as content appears. You can turn this on with \`animateIn\`.
 
 \`\`\`
-<ScrollBox animateIn={false}>
+<ScrollBox animateIn>
   <!-- content -->
 </ScrollBox>
 \`\`\`


### PR DESCRIPTION
Animating the scrollbox may look nice at first, but I find it makes an app seem slower and can be distracting / monotonous.

Since this was never a UX request, I'm turning it off as a default behavior. I also sped it up if you do choose to use it. Half a second is a long time in UI.