### PR TITLE
Align toggle with design system, add fonts to bootstrap

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -31,7 +31,10 @@ injectGlobal`
     height: 100%;
   }
 
-  /* fonts - icons */
+  /* font - brand font */
+  @import url('https://fonts.googleapis.com/css?family=Overpass:100,100i,200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i');
+
+  /* font - icons */
   @font-face {
     font-family: 'Bandwidth';
     src: url(${eot});

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -1,11 +1,14 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
+const HEIGHT = '24px';
+const WIDTH = '48px';
+
 export const HiddenInput = styled.input`
   margin: -9999px;
 
   &:focus + label::before {
-    box-shadow: ${({ theme }) => theme.toggle.focusShadow};
+    box-shadow: ${({ theme }) => theme.shadows.focusOutline};
   }
 `;
 
@@ -13,22 +16,23 @@ const Toggle = styled.label`
   cursor: pointer;
   position: relative;
   top: 50%;
-  padding: ${({ theme }) => theme.toggle.padding};
+  padding: ${({ theme }) => `${theme.padding.extraSmall} 0 ${theme.padding.extraSmall} ${theme.padding.extraLarge}`};
   float: left;
   user-select: none;
   transition: all 0.2s ease;
-  line-height: ${({ theme }) => theme.toggle.height};
-  font-family: ${({ theme }) => theme.toggle.fontFamily};
-  font-weight: ${({ theme }) => theme.toggle.fontWeight};
+  line-height: ${HEIGHT};
+  font-family: ${({ theme }) => theme.fonts.brand};
+  font-weight: 300;
   transform: translateY(-50%);
+  color: ${({ theme }) => theme.colors.grayMed};
 
   &::before {
     content: '';
-    background: ${({ theme, active }) => active ? theme.toggle.activeBG : theme.toggle.bg};
-    border: ${({ theme }) => theme.toggle.border};
-    border-radius: 2em;
-    width: ${({ theme }) => theme.toggle.width};
-    height: ${({ theme }) => theme.toggle.height};
+    background: ${({ theme, active }) => active ? theme.colors.secondary : theme.colors.white};
+    border: 2px solid ${({ theme }) => theme.colors.secondary};
+    border-radius: ${HEIGHT};
+    width: ${WIDTH};
+    height: ${HEIGHT};
     cursor: pointer;
     display: block;
     position: absolute;
@@ -40,30 +44,30 @@ const Toggle = styled.label`
 
   &::after {
     content: '';
-    background: ${({ theme, active }) => active ? theme.toggle.activeFG : theme.toggle.fg};
-    border: ${({ theme }) => theme.toggle.border};
-    border-radius: 2em;
-    width: ${({ theme }) => theme.toggle.height};
-    height: ${({ theme }) => theme.toggle.height};
+    background: ${({ theme }) => theme.colors.white};
+    border: 2px solid ${({ theme }) => theme.colors.secondary};
+    border-radius: ${HEIGHT};
+    width: ${HEIGHT};
+    height: ${HEIGHT};
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    left: ${({ active }) => active ? '1.7em' : 0};
+    left: ${({ active }) => active ? HEIGHT : 0};
     display: block;
     transition: all 0.2s ease;
   }
 
   &:hover::before,
   &:hover::after {
-    border: ${({ theme }) => theme.toggle.hoverBorder};
+    border: 2px solid ${({ theme }) => theme.colors.primaryDark};
   }
   &:hover::before {
-    background: ${({ theme, active }) => active ? theme.toggle.hoverBG : theme.toggle.bg};
+    background: ${({ theme, active }) => active ? theme.colors.primaryDark : theme.colors.white};
   }
 
   &:disabled::before, &:disabled::after {
-    border: ${({ theme }) => theme.toggle.disabledBorder};
-    background: ${({ theme }) => theme.toggle.disabledBG};
+    border: 2px solid ${({ theme }) => theme.colors.disabled};
+    background: ${({ theme }) => theme.colors.disabled};
   }
 `;
 

--- a/src/theme/baseTheme.js
+++ b/src/theme/baseTheme.js
@@ -5,6 +5,7 @@ const colors = {
   primary: '#00bcec',
   primaryText: '#008db1',
   primaryLight: '#d9f5fc',
+  primaryDark: '#008db1',
 
   secondary: '#1f2a44',
   secondaryText: '#3a455c',
@@ -205,25 +206,6 @@ export default {
     letterSpacing: '0.02em',
     fontFamily: fonts.brand,
     requiredMarkFG: '#e8562e',
-  },
-
-  toggle: {
-    bg: '#fff',
-    fg: '#fff',
-    activeBG: '#3a455c',
-    activeFG: '#fff',
-    border: '2px solid #3a455c',
-    activeBorder: '2px solid #3a455c',
-    disabledBG: '#666',
-    disabledBorder: '2px solid #666',
-    hoverBorder: '2px solid #008db1',
-    hoverBG: '#008db1',
-    focusShadow: '0 0 0 5px #d9f5fc',
-    padding: '0.2em 0 0.2em 4.2em',
-    height: '2em',
-    width: '3.6em',
-    fontFamily: fonts.brand,
-    fontWeight: 600,
   },
 
   checkbox: {


### PR DESCRIPTION
Pulls toggle details out of theme and back into the component, aligns the properties with latest design system. Also adds fonts to the base CSS bootstrapping; details about Toggle's use of the theme made this seem like a good idea to avoid library users from screwing up the rendering with inconsistent Overpass weights.