### PR TITLE
Field errors

### DIFF
--- a/docs/Alert.md
+++ b/docs/Alert.md
@@ -1,7 +1,17 @@
 Alert
-====
+=====
 
-      
+
+Props
+-----
+
+Prop                  | Type     | Default                   | Required | Description
+--------------------- | -------- | ------------------------- | -------- | -----------
+type|enum('info'\|'success'|'error')|'info'|No|An alert type; one of [info, success, error].
+textOnly|bool|false|No|Whether to render only text (true) or an icon alongside text (false).
+className|string|null|No|Additional class name to pass to the alert.
+id|string|null|No|Additional id to pass to the alert.
+
 Alerts control their own color based on `type`.
 
 * `type`: `['info', 'success', 'error']`

--- a/docs/FieldWrapper.md
+++ b/docs/FieldWrapper.md
@@ -15,6 +15,7 @@ callout|node|null|No|Content of the callout displayed when the user hovers the f
 children|node||Yes|The field input itself.
 id|string|null|No|Adds an id to the field wrapper container.
 className|string|null|No|Adds a class name to the field wrapper container.
+error|string|null|No|An error message related to this field
 type||'text'|No|
 
 # FieldWrapper

--- a/docs/Input.md
+++ b/docs/Input.md
@@ -15,5 +15,7 @@ required|bool|false|No|Controls whether the element is marked as required for fo
 id|string|null|No|Adds an id to the element.
 className|string|null|No|Adds a class name to the element.
 type|string|'text'|No|Sets the type of data expected for this input.
+invalid|bool|false|No|Styles this input as being invalid
+error|bool|false|No|Styles this input as having an error related to it
 
 A basic styled text input.

--- a/docs/TextField.md
+++ b/docs/TextField.md
@@ -8,6 +8,12 @@ Props
 Prop                  | Type     | Default                   | Required | Description
 --------------------- | -------- | ------------------------- | -------- | -----------
 input|shape[object Object]||Yes|A collection of input props. Passed to input.
+meta|shape[object Object]|{
+  error: null,
+  invalid: false,
+  pristine: false,
+  warning: null,
+}|No|
 disabled|bool|false|No|Indicates whether the user can change this field.
 required|bool|false|No|Indicates whether this field is required for form submission.
 label|string|null|No|Contents of a label above the field.

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -132,9 +132,16 @@ class Accordion extends React.Component {
         .on('tick', easer((percent) => {
           const directionalPercent = isCollapsed ? 1.0 - percent : percent;
           content.style.height = `${naturalHeight * directionalPercent}px`;
-        })).play();
+        }))
+        .on('stop', () => {
+          // after an animation has expanded the accordion, switch to
+          // auto so it reacts to changes in content size or window size automatically
+          if (!isCollapsed) {
+            content.style.height = 'auto';
+          }
+        }).play();
     } else {
-      content.style.height = isCollapsed ? 0 : naturalHeight;
+      content.style.height = isCollapsed ? 0 : 'auto';
     }
   };
 
@@ -157,7 +164,12 @@ class Accordion extends React.Component {
 
   renderContent = () => (
     <Content
-      innerRef={(el) => { this._content = el; }}
+      innerRef={
+        (el) => {
+          this._content = el;
+          this.setContentCollapseState(false);
+        }
+      }
       isCollapsed={this.calcIsCollapsed()}
     >
       <ContentHolder>

--- a/src/components/HelpText/HelpText.js
+++ b/src/components/HelpText/HelpText.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const HelpText = styled.div.withConfig({ displayName: 'HelpText' })`
-  color: ${({ theme }) => theme.helpText.fg};
+  color: ${({ theme, error }) => error ? theme.colors.errorText : theme.helpText.fg};
   font-style: italic;
   font-weight: ${({ theme }) => theme.helpText.fontWeight};
   padding: ${({ theme }) => theme.input.helpTextPadding};
@@ -18,6 +18,10 @@ HelpText.propTypes = {
    * Adds an id to the element.
    */
   id: PropTypes.string,
+  /**
+   * Whether this help text is in an error state
+   */
+  error: PropTypes.bool,
 };
 
 HelpText.defaultProps = {

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -34,8 +34,17 @@ const StyledInput = styled.input`
     css`
       &:invalid {
         box-shadow: inset 0 -5px 0 ${theme.colors.errorBackgroundLight};
+        border: 1px solid ${theme.colors.errorBorder};
       }
     ` : ''
+  }
+
+  ${({ invalid, error, theme }) => invalid || error ?
+    `
+    box-shadow: inset 0 -5px ${theme.colors.errorBackgroundLight};
+    border: 1px solid ${theme.colors.errorBorder};
+    ` :
+    ''
   }
 `;
 
@@ -73,6 +82,14 @@ class Input extends React.Component {
      * Sets the type of data expected for this input.
      */
     type: PropTypes.string,
+    /**
+     * Styles this input as being invalid
+     */
+    invalid: PropTypes.bool,
+    /**
+     * Styles this input as having an error related to it
+     */
+    error: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -83,6 +100,8 @@ class Input extends React.Component {
     onChange: () => null,
     onBlur: () => null,
     className: null,
+    invalid: false,
+    error: false,
   };
 
   constructor(props) {
@@ -98,10 +117,17 @@ class Input extends React.Component {
   };
 
   render() {
-    const { disabled, id, className } = this.props;
+    const { disabled, id, className, invalid } = this.props;
     const { visited } = this.state;
     return (
-      <StyledInput {...this.props} onBlur={this.onBlur} visited={visited} id={id} className={className} />
+      <StyledInput
+        {...this.props}
+        onBlur={this.onBlur}
+        visited={visited}
+        id={id}
+        className={className}
+        invalid={invalid}
+      />
     );
   }
 }

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -11,6 +11,7 @@ const Container = styled.header.withConfig({ displayName: 'NavigationContainer' 
   border-bottom: 1px solid ${({ theme }) => theme.shadow.color};
   padding: ${({ theme }) => theme.topNav.padding};
   display: flex;
+  flex-shrink: 0;
   justify-content: space-between;
   z-index: 1000;
 

--- a/src/layouts/Form/FieldWrapper.js
+++ b/src/layouts/Form/FieldWrapper.js
@@ -50,6 +50,10 @@ class FieldWrapper extends React.Component {
      * Adds a class name to the field wrapper container.
      */
     className: PropTypes.string,
+    /**
+     * An error message related to this field
+     */
+    error: PropTypes.string,
   };
 
   static defaultProps = {
@@ -61,6 +65,7 @@ class FieldWrapper extends React.Component {
     type: 'text',
     helpText: null,
     callout: null,
+    error: null,
   };
 
   renderChildren() {
@@ -73,12 +78,12 @@ class FieldWrapper extends React.Component {
   }
 
   render() {
-    const { label, disabled, required, helpText, id, className } = this.props;
+    const { label, disabled, required, helpText, id, className, error } = this.props;
     return (
       <Container id={id} className={className}>
         {label ? <Label required={required} disabled={disabled}>{label}</Label> : null}
         {this.renderChildren()}
-        {helpText ? <HelpText>{helpText}</HelpText> : null}
+        {helpText || error ? <HelpText error={!!error}>{error || helpText}</HelpText> : null}
       </Container>
     );
   }

--- a/src/layouts/Form/TextField.js
+++ b/src/layouts/Form/TextField.js
@@ -12,6 +12,13 @@ class TextField extends React.Component {
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       onChange: PropTypes.func,
     }).isRequired,
+
+    meta: PropTypes.shape({
+      error: PropTypes.string,
+      invalid: PropTypes.bool,
+      pristine: PropTypes.bool,
+      warning: PropTypes.string,
+    }),
     /**
      * Indicates whether the user can change this field.
      */
@@ -60,20 +67,28 @@ class TextField extends React.Component {
     helpText: null,
     callout: null,
     placeholder: null,
+    meta: {
+      error: null,
+      invalid: false,
+      pristine: false,
+      warning: null,
+    },
   };
 
   render() {
-    const { input, label, id, className, disabled, required, helpText, type, callout, placeholder } = this.props;
+    const { input, label, id, className, disabled, required, helpText, type, callout, placeholder, meta } = this.props;
     return (
       <FieldWrapper
         label={label}
         helpText={helpText}
+        error={meta.error}
         disabled={disabled}
         required={required}
         callout={callout}
       >
         <TextInput
           {...input}
+          {...meta}
           id={id}
           className={className}
           type={type}


### PR DESCRIPTION
Includes:

* Text Field now displays field-level errors via `meta` prop. This prop is normally provided by redux-form so it will integrate seamlessly.
* A big improvement for Accordion's responsiveness to its content size changing after expansion (tangential, related to other things I was working on with field errors)
* A fix for Navigation collapsing within a FlexBox as siblings expand (another tangential fix thrown in due to the use cases driving this addition)