### PR TITLE
Change invalid CSS property in loader

### DIFF
--- a/src/components/Loader/Loader.js
+++ b/src/components/Loader/Loader.js
@@ -27,7 +27,7 @@ export const Dot = styled.div.withConfig({ displayName: 'LoaderDot' })`
   height: ${({ size }) => size};
   width: ${({ size }) => size};
 
-  border-thickness: 2px;
+  border-width: 2px;
   border-style: solid;
   border-color: ${({ theme, color }) => color ? color : theme.colors.primary};
   border-radius: 50%;


### PR DESCRIPTION
Fixes loader to use `border-width` instead of `border-thickness`. Resolves issue with loader not appearing. 