### PR TITLE
KAT-1895 add show/hide by default in password field [2.0.7 - patch]

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandwidth/shared-components",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandwidth/shared-components",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Shared Component Library for Bandwidth React Apps",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
+import Anchor from '../Anchor';
 
 const StyledInput = styled.input`
   color: ${({ theme }) => theme.colors.black};
@@ -15,6 +16,7 @@ const StyledInput = styled.input`
   padding: ${({ theme }) => theme.padding.medium};
   display: block;
   border: ${({ theme }) => theme.input.border};
+
 
   &:focus {
     box-shadow: inset 0 -5px 0 ${({ theme }) => theme.colors.primaryLight};
@@ -95,7 +97,8 @@ class Input extends React.Component {
      */
     type: PropTypes.oneOf([
       'search', 'email', 'url', 'tel', 'number', 'range', 'date',
-      'month', 'week', 'time', 'datetime', 'datetime-local', 'color'
+      'month', 'week', 'time', 'datetime', 'datetime-local', 'color',
+      'password'
     ]),
     /**
      * Styles this input as being invalid
@@ -109,7 +112,18 @@ class Input extends React.Component {
      * Placeholder text to display when the input is blank
      */
     placeholder: PropTypes.string,
+    /**
+     * Disables the ability to show a password
+     */
+    disableShowPassword: PropTypes.bool,
+
   };
+
+  componentDidMount () {
+    this.setState({
+      _type: this.props.type
+    })
+  }
 
   static defaultProps = {
     disabled: false,
@@ -123,7 +137,8 @@ class Input extends React.Component {
     className: null,
     invalid: false,
     error: false,
-    placeholder: ''
+    placeholder: '',
+    disableShowPassword: false
   };
 
   constructor(props) {
@@ -138,7 +153,33 @@ class Input extends React.Component {
     }
   };
 
-  render() {
+  renderPasswordField = () => {
+    const toggleState = () => this.state._type === 'password' ? 'text' : 'password';
+    const handleClick = (evt) => {
+      evt.preventDefault();
+      this.setState({
+        _type: toggleState(this.state._type)
+      });
+    }
+
+    const getText = () => {
+      return this.state._type === 'password' ? 'Show' : 'Hide'
+    }
+
+    return (
+      <div style={{position:'relative'}}>
+          <div style={{position:'absolute', right: '10px', top: '25%'}}>
+            <Anchor href="" onClick={handleClick}>{getText()}</Anchor>
+          </div>
+          {this.renderInputField({
+            style: {paddingRight: '60px'}
+          })}          
+      </div>
+    )
+  }
+
+  renderInputField = (addlProps) => {
+
     const {
       disabled,
       id,
@@ -149,29 +190,43 @@ class Input extends React.Component {
       onKeyDown,
       value,
       required,
-      type,
       error,
       placeholder,
     } = this.props;
-    const { visited } = this.state;
+
+    const { visited, _type:type } = this.state;
+    
     return (
       <StyledInput
-        onBlur={this.onBlur}
-        onKeyDown={onKeyDown}
-        onFocus={onFocus}
-        visited={visited}
-        id={id}
-        className={className}
-        invalid={invalid}
-        onChange={onChange}
-        value={value}
-        required={required}
-        type={type}
-        error={error}
-        disabled={disabled}
-        placeholder={placeholder}
-      />
-    );
+          onBlur={this.onBlur}
+          onKeyDown={onKeyDown}
+          onFocus={onFocus}
+          visited={visited}
+          id={id}
+          className={className}
+          invalid={invalid}
+          onChange={onChange}
+          value={value}
+          required={required}
+          type={type}
+          error={error}
+          disabled={disabled}
+          placeholder={placeholder}
+          {...addlProps}
+        />
+        )
+  }
+    
+
+  render() {
+    
+    const { type, disableShowPassword } = this.props;
+
+    if ( type === 'password' && !disableShowPassword) {
+      return this.renderPasswordField();
+    }
+
+    return this.renderInputField();
   }
 }
 

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -54,6 +54,22 @@ const StyledInput = styled.input`
   }
 `;
 
+const RevealPasswordContainer = styled.div`
+  position: relative;
+
+  div {
+    position: absolute;
+    right: 10px; 
+    top: 25%;
+  }
+
+  input[type="password"],
+  input[type="text"] {
+    padding-right: ${({theme}) => theme.padding.extraLarge} !important;
+  }
+
+`
+
 class Input extends React.Component {
   static propTypes = {
     /**
@@ -162,23 +178,19 @@ class Input extends React.Component {
       });
     }
 
-    const getText = () => {
-      return this.state._type === 'password' ? 'Show' : 'Hide'
-    }
-
     return (
-      <div style={{position:'relative'}}>
-          <div style={{position:'absolute', right: '10px', top: '25%'}}>
-            <Anchor href="" onClick={handleClick}>{getText()}</Anchor>
+      <RevealPasswordContainer>
+          <div>
+            <Anchor href="" onClick={handleClick}>
+              {this.state._type === 'password' ? 'Show' : 'Hide'}
+            </Anchor>
           </div>
-          {this.renderInputField({
-            style: {paddingRight: '60px'}
-          })}          
-      </div>
+          {this.renderInputField()}          
+      </RevealPasswordContainer>
     )
   }
 
-  renderInputField = (addlProps) => {
+  renderInputField = () => {
 
     const {
       disabled,
@@ -212,7 +224,6 @@ class Input extends React.Component {
           error={error}
           disabled={disabled}
           placeholder={placeholder}
-          {...addlProps}
         />
         )
   }

--- a/src/components/Input/Input.md
+++ b/src/components/Input/Input.md
@@ -11,3 +11,14 @@ A basic styled text input.
 ```
 <Input type="email" placeholder="joe@domain.com"/>
 ```
+
+
+Default password field
+```
+<Input type="password" placeholder="User Password"/>
+```
+
+Password field with show/hide disabled
+```
+<Input type="password" placeholder="User Password" disableShowPassword/>
+```


### PR DESCRIPTION
- Adds a show / hide option by default for inputs of type `password`
- Developers can disable show/hide by using flag `disableShowPassword`
- Updated docs