### PR TITLE
z-ordering fix for sidebar list items

### DIFF
--- a/src/components/SidebarList/SidebarListItem.js
+++ b/src/components/SidebarList/SidebarListItem.js
@@ -11,6 +11,7 @@ const ListItemContainer = styled.li`
   border-right: 1px solid ${({ theme, active }) => active ? theme.colors.gutter : theme.colors.borderLight};
   position: relative;
   overflow-x: visible;
+  z-index: 100;
 `;
 
 const ListLabel = styled.h3`


### PR DESCRIPTION
Sidebar list items don't set a positive z-index value, but they are designed to overlap the dividing line of the SidebarLayout component. If a user makes the content of a SidebarLayout `position: relative`, or otherwise elevates its z-ordering, the SidebarListItem will no longer overlap it properly. Setting a positive z-index value maintains the behavior. 100 was chosen arbitrarily... It might be nice to establish a guideline system for z-index values if we deal enough with them in the future.