### PR TITLE
BWDB-2769 fix h3 styles in SCL

### DIFF
--- a/src/components/H/H3.js
+++ b/src/components/H/H3.js
@@ -6,9 +6,10 @@ import get from 'extensions/themeGet';
 const H3 = styled.h3.withConfig({ displayName: 'H3' })`
   color: ${get('colors.text.default')};
   font-weight: 300;
-  font-family: ${get('fonts.brand')};
+  font-family: 'Overpass', sans-serif;
   font-size: 1.75em;
-  line-height: 1em;
+  line-height: 1.25;
+  letter-spacing: 0;
   margin: 0;
   padding: 0;
 `;

--- a/src/components/H/H3.js
+++ b/src/components/H/H3.js
@@ -6,7 +6,7 @@ import get from 'extensions/themeGet';
 const H3 = styled.h3.withConfig({ displayName: 'H3' })`
   color: ${get('colors.text.default')};
   font-weight: 300;
-  font-family: 'Overpass', sans-serif;
+  font-family: ${get('fonts.brand')};
   font-size: 1.75em;
   line-height: 1.25;
   letter-spacing: 0;


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x ] Visual and behavioral components are separated
- [x ] Exported components are documented with examples
- x[ ] Props have JSDoc comments
- [x ] All relevant visual sub-components can be overridden via props


## Changes to Existing Components

Acceptance Criteria
The Heading 3 style should be defined by:

color: #666;
font-family: 'Overpass', sans-serif;
font-size: 1.75em; /* 14px base * 1.75 = 24.5px */
font-weight: 300;
letter-spacing: 0;
line-height: 1.25;

