### PR TITLE
BWDB2955 added new styles + color & size variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "styleguide": "run-s styleguide:*",
     "gen": "studs generate component",
     "precommit": "lint-staged",
-    "prettier": "prettier --single-quote --trailing-comma all --write \"{src,tools,__tests__}/**/*.js\""
+    "prettier": "prettier --single-quote --trailing-comma all --write \"{src,tools,__tests__}/**/*.js\"",
+    "start": "npm run styleguide"
   },
   "lint-staged": {
     "*.js": [

--- a/src/components/BulkSelect/BulkSelect.js
+++ b/src/components/BulkSelect/BulkSelect.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { withProps } from 'recompose';
 import theme from '../../theme';
 import styled from 'styled-components';
 import BulkSelectItem from './styles/BulkSelectItem';
@@ -97,6 +98,7 @@ class BulkSelect extends React.Component {
             <Item
               key={computeItemKey(item.data)}
               selected={item.selected}
+              disabled={item.disabled}
               onClick={this.createItemClickHandler(item)}
             >
               {resolvedRenderItemContents(item.data, item.selected)}
@@ -113,5 +115,11 @@ class BulkSelect extends React.Component {
     return <Border>{sections.map(this.renderSection)}</Border>;
   }
 }
+
+BulkSelect.Small = withProps({ ItemContainer: BulkSelectItemContainer.Small })(
+  BulkSelect,
+);
+
+BulkSelect.Colorful = withProps({ Item: BulkSelectItem.Colorful })(BulkSelect);
 
 export default BulkSelect;

--- a/src/components/BulkSelect/BulkSelect.md
+++ b/src/components/BulkSelect/BulkSelect.md
@@ -1,23 +1,56 @@
 ```javascript
-<BulkSelect
-  sections={[
-    {
-      title: 'Section 1',
-      items: [
-        { data: 'Foo', selected: true },
-        { data: 'Bar', selected: false },
-      ],
-    },
-    {
-      title: 'Section 2',
-      items: [
-        { data: 'Baz', selected: false },
-        { data: 'Corge', selected: true },
-        { data: 'Thud', selected: true },
-      ],
-    },
-  ]}
-  renderItem={(item) => item}
-  computeItemKey={(item) => item}
-/>
+<div>
+  <BulkSelect
+    sections={[
+      {
+        title: 'Section 1',
+        items: [
+          { data: 'Foo', selected: true },
+          { data: 'Bar', selected: false },
+        ],
+      },
+      {
+        title: 'Section 2',
+        items: [
+          { data: 'Baz', selected: false },
+          { data: 'Corge', selected: true },
+          { data: 'Thud', selected: false, disabled: true },
+          { data: 'Dunk', selected: true, disabled: true },
+        ],
+      },
+    ]}
+    renderItem={(item) => item}
+    computeItemKey={(item) => item}
+  />
+  <BulkSelect.Small
+    sections={[
+      {
+        title: 'Small Variant',
+        items: [
+          { data: '1', selected: false },
+          { data: '2', selected: true },
+          { data: '3', selected: false, disabled: true },
+          { data: '4', selected: true, disabled: true  },
+          { data: '5', selected: false },
+          { data: '6', selected: true },
+        ],
+      },
+    ]}
+    renderItem={(item) => item}
+    computeItemKey={(item) => item}
+  />
+  <BulkSelect.Colorful
+    sections={[
+      {
+        title: 'Color Variant',
+        items: [
+          { data: 'Clank', selected: true },
+          { data: 'Pow', selected: false },
+        ],
+      },
+    ]}
+    renderItem={(item) => item}
+    computeItemKey={(item) => item}
+  />
+</div>
 ```

--- a/src/components/BulkSelect/styles/BulkSelectBorder.js
+++ b/src/components/BulkSelect/styles/BulkSelectBorder.js
@@ -2,10 +2,6 @@ import styled from 'styled-components';
 import get from 'extensions/themeGet';
 
 export default styled.div`
-  border-width: ${get('thicknesses.normal')};
-  border-color: ${get('colors.gray.border')};
-  border-style: solid;
-  background: ${get('colors.gray.light')};
   padding: ${get('spacing.medium')};
   overflow-y: auto;
 `;

--- a/src/components/BulkSelect/styles/BulkSelectItem.js
+++ b/src/components/BulkSelect/styles/BulkSelectItem.js
@@ -1,27 +1,64 @@
 import styled, { css } from 'styled-components';
 import get from 'extensions/themeGet';
 
-export default styled.div`
+const BulkSelectItem = styled.button`
   padding: ${get('spacing.small')} ${get('spacing.medium')};
   background: ${get('colors.background.default')};
-  color: ${get('colors.text.default')};
-  border-color: ${get('colors.border.medium')};
-  border-width: ${get('thicknesses.normal')};
+  border-color: ${get('colors.border.dark')};
+  border-width: ${get('thicknesses.wide')};
   border-style: solid;
   border-radius: 3px;
   cursor: pointer;
   margin: ${get('spacing.small')} calc(${get('spacing.small')} / 2);
   display: flex;
 
+  color: ${get('colors.primary.dark')};
+  font-weight: 700;
+  text-align: center;
+  text-transform: uppercase;
+  cursor: pointer;
+  user-select: none;
+  transition: 0.2s ease;
+  font-size: 14px;
+
+  &:disabled {
+    color: ${get('colors.text.disabled')};
+    background-color: ${get('colors.background.disabled')};
+    border-color: ${get('colors.border.disabled')};
+    cursor: default;
+  }
+
   ${({ selected }) =>
     selected
       ? css`
-          background: ${get('colors.primary.default')};
+          background: ${get('colors.primary.dark')};
           color: ${get('colors.text.inverted')};
-          border-color: ${get('colors.primary.default')};
+          border-color: ${get('colors.primary.dark')};
+          &:hover:not(:disabled) {
+            box-shadow: ${get('shadows.focusOutline')};
+          }
+          &:disabled {
+            background-color: ${get('colors.background.disabledSelected')};
+            border-color: ${get('colors.border.disabled')};
+            color: ${get('colors.text.inverted')};
+          }
         `
-      : ''} &:hover {
-    background: ${get('colors.primary.light')};
-    color: ${get('colors.text.default')};
-  }
+      : ''};
 `;
+
+BulkSelectItem.Colorful = styled(BulkSelectItem)`
+  ${({ selected }) =>
+    selected
+      ? css`
+          background-color: ${get('colors.positive.medium')};
+          border-color: ${get('colors.positive.medium')};
+          color: ${get('colors.text.inverted')};
+          &:hover:not(:disabled) {
+            background-color: ${get('colors.negative.medium')};
+            border-color: ${get('colors.negative.medium')};
+          }
+        `
+      : ''};
+`;
+
+export default BulkSelectItem;

--- a/src/components/BulkSelect/styles/BulkSelectItemContainer.js
+++ b/src/components/BulkSelect/styles/BulkSelectItemContainer.js
@@ -1,14 +1,30 @@
 import styled from 'styled-components';
 import get from 'extensions/themeGet';
 
-export default styled.div`
+const BulkSelectItemContainer = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
 
-  & > div {
+  & > button {
     flex-grow: 0;
     flex-shrink: 0;
     flex-basis: calc((1 / 5 - ${get('spacing.small')}));
+    height: 53px;
+    margin: 7.5px;
+    padding: 0 10px;
+    min-width: 53px;
   }
 `;
+
+BulkSelectItemContainer.Small = styled(BulkSelectItemContainer)`
+  & > button {
+    height: 30px;
+    font-size: 0.8em;
+    margin: 2.5px;
+    padding: 0 10px;
+    min-width: 30px;
+  }
+`;
+
+export default BulkSelectItemContainer;

--- a/src/components/Radio/Radio.js
+++ b/src/components/Radio/Radio.js
@@ -93,12 +93,17 @@ class Radio extends React.Component {
           type="radio"
           value={value}
           name={name}
-          disabled={disabled}
+          disabled={!!disabled}
           checked={!!checked}
-          required={required}
+          required={!!required}
           onChange={onChange}
         />
-        <Label htmlFor={id} checked={!!checked}>
+        <Label
+          htmlFor={id}
+          checked={!!checked}
+          disabled={!!disabled}
+          required={!!required}
+        >
           {description}
         </Label>
       </Container>

--- a/src/components/Radio/Radio.md
+++ b/src/components/Radio/Radio.md
@@ -13,6 +13,7 @@
     }
   />
   <Radio disabled value="hello" description="Can't check this"/>
+  <Radio disabled checked value="hello" description="Can't uncheck this"/>
 </div>
 ```
 

--- a/src/components/Radio/styles/RadioContainer.js
+++ b/src/components/Radio/styles/RadioContainer.js
@@ -3,4 +3,5 @@ import styled from 'styled-components';
 export default styled.div`
   display: block;
   position: relative;
+  margin-bottom: 5px;
 `;

--- a/src/components/Radio/styles/RadioInput.js
+++ b/src/components/Radio/styles/RadioInput.js
@@ -1,31 +1,43 @@
 import styled from 'styled-components';
 import get from 'extensions/themeGet';
+import icons from 'components/Icon/icons';
 
 export default styled.input`
   opacity: 0;
   position: absolute;
   z-index: -1000000;
+  transition: all 0.2s ease;
 
-  &:active:not(:disabled) + label::after {
-    border-color: ${get('colors.primary.dark')};
+  /* the check */
+
+  &:checked + label::before {
+    content: "${icons('checkmark')}";
   }
+
+  /* the bubble */
+
+  & + label::after {
+    border-color: ${get('colors.border.dark')};
+  }
+
+  &:disabled + label::after {
+    border-color: ${get('colors.border.disabled')};
+  }
+
+  &:disabled:checked + label::after {
+    background-color: ${get('colors.background.disabledSelected')};
+  }
+
+  &:disabled:not(:checked) + label::after {
+    background-color: ${get('colors.background.disabled')};
+  }
+
   &:checked:not(:disabled) + label::after {
-    background: ${get('colors.primary.dark')};
+    background-color: ${get('colors.background.dark')};
   }
-  &:active:not(:disabled) + label::after {
-    border-color: ${get('colors.primary.alternate')};
+
+  &:not(:checked):not(:disabled) + label::after {
+    background-color: ${get('colors.background.default')};
   }
-  &:checked:active:not(:disabled) + label::after {
-    background: ${get('colors.primary.alternate')};
-  }
-  &:focus:not(:hover) + label::after {
-    box-shadow: ${get('shadows.focusOutline')};
-  }
-  &:disabled + label {
-    opacity: 0.5;
-    cursor: default;
-  }
-  &:disabled + label::before {
-    color: ${get('colors.gray.medium')};
-  }
+
 `;

--- a/src/components/Radio/styles/RadioLabel.js
+++ b/src/components/Radio/styles/RadioLabel.js
@@ -2,44 +2,68 @@ import styled from 'styled-components';
 import get from 'extensions/themeGet';
 import icons from 'components/Icon/icons';
 
-const SIZE = '1.3em';
-const PADDING = '0.2em';
+const SIZE = '30px';
+const PADDING = '0.5em';
+const BORDER_WIDTH = '2px';
+
+const calcLabelColor = ({ disabled }) => {
+  if (disabled) return get('colors.text.disabled');
+  return get('colors.text.default');
+};
 
 export default styled.label`
   display: block;
   cursor: pointer;
   position: relative;
-  padding: ${PADDING} 0 ${PADDING} 2.1em;
+  padding-left: calc(${SIZE} + 10px);
+  padding-top: 4px;
   line-height: 1.5em;
+  min-height: ${SIZE};
+  color: ${calcLabelColor};
+  /*
+    We need to attach the hover to the label because it isn't
+    hidden from view like the checkbox is. However, <label>
+    doesn't support the disabled attribute natively.
+  */
+  &:hover::after,
+  &:focus::after,
+  &:active::after {
+    box-shadow: ${({ disabled }) =>
+      disabled ? '' : get('shadows.focusOutline')};
+  }
 
   /* the check */
 
   &::before {
-    content: ${({ checked }) => (checked ? `"${icons('checkmark')}"` : '""')};
-    color: ${get('colors.text.inverted')};
+    /* label color will take precedence over this unless we mark it important */
+    color: ${get('colors.text.inverted')} !important;
     font-family: ${get('fonts.icon')};
     text-align: center;
     width: ${SIZE};
     height: ${SIZE};
     display: block;
     position: absolute;
-    top: calc(${PADDING} + ${SIZE} / 2);
+    top: 50%;
     left: calc(${SIZE} / 2);
     transform: translate(-50%, -50%);
     z-index: 1;
+    font-size: 1.5em;
+    line-height: 1.5;
+    transition: all 0.2s ease;
   }
 
   /* the bubble */
 
   &::after {
     content: '';
-    border: ${get('thicknesses.wide')} solid ${get('colors.primary.dark')};
-    border-radius: 100%;
-    width: ${SIZE};
-    height: ${SIZE};
+    border-style: solid;
+    border-radius: ${SIZE};
+    border-width: ${BORDER_WIDTH};
+    width: calc(${SIZE} - 2 * ${BORDER_WIDTH});
+    height: calc(${SIZE} - 2 * ${BORDER_WIDTH});
     display: block;
     position: absolute;
-    top: calc(${PADDING} + ${SIZE} / 2);
+    top: 50%;
     left: calc(${SIZE} / 2);
     transform: translate(-50%, -50%);
     transition: all 0.2s ease;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,8 @@
-
 /**
  * THIS IS A GENERATED FILE
  *
  * Please see /tools/generateIndices.js to regenerate after structural changes or component additions / deletions
  */
-
 
 export { default as bootstrap } from './/bootstrap';
 export { default as animations } from './animations';
@@ -12,77 +10,165 @@ export { default as Expand } from './animations/Expand';
 export { default as behaviors } from './behaviors';
 export { default as ExpandToggle } from './behaviors/ExpandToggle';
 export { default as Accordion } from './components/Accordion';
-export { default as AccordionGroup } from './components/Accordion/AccordionGroup';
-export { default as AccordionArrow } from './components/Accordion/styles/AccordionArrow';
-export { default as AccordionBorder } from './components/Accordion/styles/AccordionBorder';
-export { default as AccordionContent } from './components/Accordion/styles/AccordionContent';
-export { default as AccordionGroupContainer } from './components/Accordion/styles/AccordionGroupContainer';
-export { default as AccordionLabel } from './components/Accordion/styles/AccordionLabel';
-export { default as AccordionLabelText } from './components/Accordion/styles/AccordionLabelText';
+export {
+  default as AccordionGroup,
+} from './components/Accordion/AccordionGroup';
+export {
+  default as AccordionArrow,
+} from './components/Accordion/styles/AccordionArrow';
+export {
+  default as AccordionBorder,
+} from './components/Accordion/styles/AccordionBorder';
+export {
+  default as AccordionContent,
+} from './components/Accordion/styles/AccordionContent';
+export {
+  default as AccordionGroupContainer,
+} from './components/Accordion/styles/AccordionGroupContainer';
+export {
+  default as AccordionLabel,
+} from './components/Accordion/styles/AccordionLabel';
+export {
+  default as AccordionLabelText,
+} from './components/Accordion/styles/AccordionLabelText';
 export { default as Alert } from './components/Alert';
 export { default as AlertBorder } from './components/Alert/styles/AlertBorder';
 export { default as AlertIcon } from './components/Alert/styles/AlertIcon';
 export { default as AlertText } from './components/Alert/styles/AlertText';
 export { default as Anchor } from './components/Anchor';
 export { default as DomSafeLink } from './components/Anchor/styles/DomSafeLink';
-export { default as ExternalContentAnchor } from './components/Anchor/styles/ExternalContentAnchor';
-export { default as ExternalIconAnchor } from './components/Anchor/styles/ExternalIconAnchor';
-export { default as ExternalTextAnchor } from './components/Anchor/styles/ExternalTextAnchor';
-export { default as InternalContentAnchor } from './components/Anchor/styles/InternalContentAnchor';
-export { default as InternalIconAnchor } from './components/Anchor/styles/InternalIconAnchor';
-export { default as InternalTextAnchor } from './components/Anchor/styles/InternalTextAnchor';
+export {
+  default as ExternalContentAnchor,
+} from './components/Anchor/styles/ExternalContentAnchor';
+export {
+  default as ExternalIconAnchor,
+} from './components/Anchor/styles/ExternalIconAnchor';
+export {
+  default as ExternalTextAnchor,
+} from './components/Anchor/styles/ExternalTextAnchor';
+export {
+  default as InternalContentAnchor,
+} from './components/Anchor/styles/InternalContentAnchor';
+export {
+  default as InternalIconAnchor,
+} from './components/Anchor/styles/InternalIconAnchor';
+export {
+  default as InternalTextAnchor,
+} from './components/Anchor/styles/InternalTextAnchor';
 export { default as BandwidthProvider } from './components/BandwidthProvider';
-export { default as StyleRoot } from './components/BandwidthProvider/styles/StyleRoot';
-export { default as BandwidthThemeProvider } from './components/BandwidthThemeProvider';
+export {
+  default as StyleRoot,
+} from './components/BandwidthProvider/styles/StyleRoot';
+export {
+  default as BandwidthThemeProvider,
+} from './components/BandwidthThemeProvider';
 export { default as Breadcrumb } from './components/Breadcrumb';
 export { default as Breadcrumbs } from './components/Breadcrumb/Breadcrumbs';
 export { default as BulkSelect } from './components/BulkSelect';
-export { default as BulkSelectBorder } from './components/BulkSelect/styles/BulkSelectBorder';
-export { default as BulkSelectDivider } from './components/BulkSelect/styles/BulkSelectDivider';
-export { default as BulkSelectItem } from './components/BulkSelect/styles/BulkSelectItem';
-export { default as BulkSelectItemContainer } from './components/BulkSelect/styles/BulkSelectItemContainer';
+export {
+  default as BulkSelectBorder,
+} from './components/BulkSelect/styles/BulkSelectBorder';
+export {
+  default as BulkSelectDivider,
+} from './components/BulkSelect/styles/BulkSelectDivider';
+export {
+  default as BulkSelectItem,
+} from './components/BulkSelect/styles/BulkSelectItem';
+export {
+  default as BulkSelectItemContainer,
+} from './components/BulkSelect/styles/BulkSelectItemContainer';
 export { default as Button } from './components/Button';
 export { default as SubmitButton } from './components/Button/SubmitButton';
 export { default as Callout } from './components/Callout';
 export { default as CalloutTag } from './components/Callout/styles/CalloutTag';
 export { default as Card } from './components/Cards/Card';
 export { default as CardGroup } from './components/Cards/CardGroup';
-export { default as CardGroupConnected } from './components/Cards/CardGroupConnected';
+export {
+  default as CardGroupConnected,
+} from './components/Cards/CardGroupConnected';
 export { default as CardHeader } from './components/Cards/CardHeader';
 export { default as CardSection } from './components/Cards/CardSection';
-export { default as CardHeaderText } from './components/Cards/styles/CardHeaderText';
+export {
+  default as CardHeaderText,
+} from './components/Cards/styles/CardHeaderText';
 export { default as CardWrapper } from './components/Cards/styles/CardWrapper';
-export { default as HeaderWrapper } from './components/Cards/styles/HeaderWrapper';
+export {
+  default as HeaderWrapper,
+} from './components/Cards/styles/HeaderWrapper';
 export { default as Checkbox } from './components/Checkbox';
-export { default as CheckboxContainer } from './components/Checkbox/styles/CheckboxContainer';
-export { default as CheckboxInput } from './components/Checkbox/styles/CheckboxInput';
-export { default as CheckboxLabel } from './components/Checkbox/styles/CheckboxLabel';
+export {
+  default as CheckboxContainer,
+} from './components/Checkbox/styles/CheckboxContainer';
+export {
+  default as CheckboxInput,
+} from './components/Checkbox/styles/CheckboxInput';
+export {
+  default as CheckboxLabel,
+} from './components/Checkbox/styles/CheckboxLabel';
 export { default as Code } from './components/Code';
 export { default as CodeBlock } from './components/Code/CodeBlock';
 export { default as DatePicker } from './components/DatePicker';
-export { default as DateRangePicker } from './components/DatePicker/DateRangePicker';
-export { default as DatePickerWrapper } from './components/DatePicker/styles/DatePickerWrapper';
-export { default as DateRangePickerLineSeparator } from './components/DatePicker/styles/DateRangePickerLineSeparator';
-export { default as DateRangePickerWrapper } from './components/DatePicker/styles/DateRangePickerWrapper';
+export {
+  default as DateRangePicker,
+} from './components/DatePicker/DateRangePicker';
+export {
+  default as DatePickerWrapper,
+} from './components/DatePicker/styles/DatePickerWrapper';
+export {
+  default as DateRangePickerLineSeparator,
+} from './components/DatePicker/styles/DateRangePickerLineSeparator';
+export {
+  default as DateRangePickerWrapper,
+} from './components/DatePicker/styles/DateRangePickerWrapper';
 export { default as DragGroup } from './components/DragGroup';
-export { default as DragGroupDropArea } from './components/DragGroup/DragGroupDropArea';
+export {
+  default as DragGroupDropArea,
+} from './components/DragGroup/DragGroupDropArea';
 export { default as DragGroupItem } from './components/DragGroup/DragGroupItem';
-export { default as DragGroupContainer } from './components/DragGroup/styles/DragGroupContainer';
-export { default as DragGroupDropAreaContent } from './components/DragGroup/styles/DragGroupDropAreaContent';
-export { default as DragGroupItemsContainer } from './components/DragGroup/styles/DragGroupItemsContainer';
-export { default as DragItemContainer } from './components/DragGroup/styles/DragItemContainer';
-export { default as DragGroupSeparator } from './components/DragGroup/styles/DragGroupSeparator';
-export { default as DragGroupSeparatorContainer } from './components/DragGroup/styles/DragGroupSeparator/DragGroupSeparatorContainer';
-export { default as DragGroupSeparatorContent } from './components/DragGroup/styles/DragGroupSeparator/DragGroupSeparatorContent';
-export { default as DragGroupTitle } from './components/DragGroup/styles/DragGroupTitle';
-export { default as DragGroupTitleContainer } from './components/DragGroup/styles/DragGroupTitle/DragGroupTitleContainer';
-export { default as DragGroupTitleContent } from './components/DragGroup/styles/DragGroupTitle/DragGroupTitleContent';
+export {
+  default as DragGroupContainer,
+} from './components/DragGroup/styles/DragGroupContainer';
+export {
+  default as DragGroupDropAreaContent,
+} from './components/DragGroup/styles/DragGroupDropAreaContent';
+export {
+  default as DragGroupItemsContainer,
+} from './components/DragGroup/styles/DragGroupItemsContainer';
+export {
+  default as DragItemContainer,
+} from './components/DragGroup/styles/DragItemContainer';
+export {
+  default as DragGroupSeparator,
+} from './components/DragGroup/styles/DragGroupSeparator';
+export {
+  default as DragGroupSeparatorContainer,
+} from './components/DragGroup/styles/DragGroupSeparator/DragGroupSeparatorContainer';
+export {
+  default as DragGroupSeparatorContent,
+} from './components/DragGroup/styles/DragGroupSeparator/DragGroupSeparatorContent';
+export {
+  default as DragGroupTitle,
+} from './components/DragGroup/styles/DragGroupTitle';
+export {
+  default as DragGroupTitleContainer,
+} from './components/DragGroup/styles/DragGroupTitle/DragGroupTitleContainer';
+export {
+  default as DragGroupTitleContent,
+} from './components/DragGroup/styles/DragGroupTitle/DragGroupTitleContent';
 export { default as DragLayer } from './components/DragLayer';
-export { default as DragItemPreviewContainer } from './components/DragLayer/styles/DragItemPreviewContainer';
-export { default as DragLayerOverlay } from './components/DragLayer/styles/DragLayerOverlay';
+export {
+  default as DragItemPreviewContainer,
+} from './components/DragLayer/styles/DragItemPreviewContainer';
+export {
+  default as DragLayerOverlay,
+} from './components/DragLayer/styles/DragLayerOverlay';
 export { default as FileLoader } from './components/FileLoader';
-export { default as FileLoaderDropArea } from './components/FileLoader/styles/FileLoaderDropArea';
-export { default as FileLoaderPreview } from './components/FileLoader/styles/FileLoaderPreview';
+export {
+  default as FileLoaderDropArea,
+} from './components/FileLoader/styles/FileLoaderDropArea';
+export {
+  default as FileLoaderPreview,
+} from './components/FileLoader/styles/FileLoaderPreview';
 export { default as Form } from './components/Form';
 export { default as FormBox } from './components/Form/FormBox';
 export { default as FormColumn } from './components/Form/FormColumn';
@@ -97,7 +183,9 @@ export { default as HelpText } from './components/HelpText';
 export { default as Icon } from './components/Icon';
 export { default as icons } from './components/Icon/icons';
 export { default as Input } from './components/Input';
-export { default as InputRevealPasswordWrapper } from './components/Input/styles/InputRevealPasswordWrapper';
+export {
+  default as InputRevealPasswordWrapper,
+} from './components/Input/styles/InputRevealPasswordWrapper';
 export { default as InputStyles } from './components/Input/styles/InputStyles';
 export { default as Label } from './components/Label';
 export { default as List } from './components/List';
@@ -105,69 +193,141 @@ export { default as ListItem } from './components/List/ListItem';
 export { default as OrderedList } from './components/List/OrderedList';
 export { default as UnorderedList } from './components/List/UnorderedList';
 export { default as Loader } from './components/Loader';
-export { default as LoaderContainer } from './components/Loader/styles/LoaderContainer';
+export {
+  default as LoaderContainer,
+} from './components/Loader/styles/LoaderContainer';
 export { default as LoaderRing } from './components/Loader/styles/LoaderRing';
 export { default as Logo } from './components/Logo';
 export { default as LogoImage } from './components/Logo/styles/LogoImage';
 export { default as MethodTag } from './components/MethodTag';
 export { default as Modal } from './components/Modal';
-export { default as ModalActionContent } from './components/Modal/styles/ModalActionContent';
-export { default as ModalBlocker } from './components/Modal/styles/ModalBlocker';
-export { default as ModalContent } from './components/Modal/styles/ModalContent';
+export {
+  default as ModalActionContent,
+} from './components/Modal/styles/ModalActionContent';
+export {
+  default as ModalBlocker,
+} from './components/Modal/styles/ModalBlocker';
+export {
+  default as ModalContent,
+} from './components/Modal/styles/ModalContent';
 export { default as ModalTitle } from './components/Modal/styles/ModalTitle';
 export { default as ModalWindow } from './components/Modal/styles/ModalWindow';
 export { default as Money } from './components/Money';
 export { default as MoneyStyles } from './components/Money/styles/MoneyStyles';
 export { default as Navigation } from './components/Navigation';
-export { default as NavigationTitle } from './components/Navigation/NavigationTitle';
-export { default as NavigationBar } from './components/Navigation/styles/NavigationBar';
-export { default as NavigationHeading } from './components/Navigation/styles/NavigationHeading';
-export { default as NavigationItem } from './components/Navigation/styles/NavigationItem';
-export { default as NavigationItemList } from './components/Navigation/styles/NavigationItemList';
-export { default as NavigationItemListStack } from './components/Navigation/styles/NavigationItemListStack';
-export { default as NavigationLogoPairWrapper } from './components/Navigation/styles/NavigationLogoPairWrapper';
+export {
+  default as NavigationTitle,
+} from './components/Navigation/NavigationTitle';
+export {
+  default as NavigationBar,
+} from './components/Navigation/styles/NavigationBar';
+export {
+  default as NavigationHeading,
+} from './components/Navigation/styles/NavigationHeading';
+export {
+  default as NavigationItem,
+} from './components/Navigation/styles/NavigationItem';
+export {
+  default as NavigationItemList,
+} from './components/Navigation/styles/NavigationItemList';
+export {
+  default as NavigationItemListStack,
+} from './components/Navigation/styles/NavigationItemListStack';
+export {
+  default as NavigationLogoPairWrapper,
+} from './components/Navigation/styles/NavigationLogoPairWrapper';
 export { default as NewBadge } from './components/NewBadge';
 export { default as Note } from './components/Note';
-export { default as NoteContainer } from './components/Note/styles/NoteContainer';
+export {
+  default as NoteContainer,
+} from './components/Note/styles/NoteContainer';
 export { default as NoteCorner } from './components/Note/styles/NoteCorner';
 export { default as Pagination } from './components/Pagination';
-export { default as PaginationContainer } from './components/Pagination/styles/PaginationContainer';
-export { default as PaginationItem } from './components/Pagination/styles/PaginationItem';
-export { default as PaginationItemPlaceholder } from './components/Pagination/styles/PaginationItemPlaceholder';
+export {
+  default as PaginationContainer,
+} from './components/Pagination/styles/PaginationContainer';
+export {
+  default as PaginationItem,
+} from './components/Pagination/styles/PaginationItem';
+export {
+  default as PaginationItemPlaceholder,
+} from './components/Pagination/styles/PaginationItemPlaceholder';
 export { default as Radio } from './components/Radio';
-export { default as RadioContainer } from './components/Radio/styles/RadioContainer';
+export {
+  default as RadioContainer,
+} from './components/Radio/styles/RadioContainer';
 export { default as RadioInput } from './components/Radio/styles/RadioInput';
 export { default as RadioLabel } from './components/Radio/styles/RadioLabel';
 export { default as RadioGroup } from './components/RadioGroup';
 export { default as RadioButton } from './components/RadioGroup/RadioButton';
-export { default as RadioGroupButtonContainer } from './components/RadioGroup/styles/RadioGroupButtonContainer';
-export { default as RadioGroupButtonContent } from './components/RadioGroup/styles/RadioGroupButtonContent';
-export { default as RadioGroupButtonInput } from './components/RadioGroup/styles/RadioGroupButtonInput';
-export { default as RadioGroupButtonLabel } from './components/RadioGroup/styles/RadioGroupButtonLabel';
-export { default as RadioGroupButtonLabelText } from './components/RadioGroup/styles/RadioGroupButtonLabelText';
-export { default as RadioGroupContainer } from './components/RadioGroup/styles/RadioGroupContainer';
+export {
+  default as RadioGroupButtonContainer,
+} from './components/RadioGroup/styles/RadioGroupButtonContainer';
+export {
+  default as RadioGroupButtonContent,
+} from './components/RadioGroup/styles/RadioGroupButtonContent';
+export {
+  default as RadioGroupButtonInput,
+} from './components/RadioGroup/styles/RadioGroupButtonInput';
+export {
+  default as RadioGroupButtonLabel,
+} from './components/RadioGroup/styles/RadioGroupButtonLabel';
+export {
+  default as RadioGroupButtonLabelText,
+} from './components/RadioGroup/styles/RadioGroupButtonLabelText';
+export {
+  default as RadioGroupContainer,
+} from './components/RadioGroup/styles/RadioGroupContainer';
 export { default as SearchBox } from './components/SearchBox';
 export { default as Suggestion } from './components/SearchBox/Suggestion';
-export { default as SearchBoxSearchButton } from './components/SearchBox/styles/SearchBoxSearchButton';
-export { default as SearchBoxSuggestionContainer } from './components/SearchBox/styles/SearchBoxSuggestionContainer';
-export { default as SearchBoxSuggestionHighlightText } from './components/SearchBox/styles/SearchBoxSuggestionHighlightText';
-export { default as SearchBoxSuggestionsList } from './components/SearchBox/styles/SearchBoxSuggestionsList';
-export { default as SearchBoxSuggestionsSectionTitle } from './components/SearchBox/styles/SearchBoxSuggestionsSectionTitle';
-export { default as SearchBoxWrapper } from './components/SearchBox/styles/SearchBoxWrapper';
+export {
+  default as SearchBoxSearchButton,
+} from './components/SearchBox/styles/SearchBoxSearchButton';
+export {
+  default as SearchBoxSuggestionContainer,
+} from './components/SearchBox/styles/SearchBoxSuggestionContainer';
+export {
+  default as SearchBoxSuggestionHighlightText,
+} from './components/SearchBox/styles/SearchBoxSuggestionHighlightText';
+export {
+  default as SearchBoxSuggestionsList,
+} from './components/SearchBox/styles/SearchBoxSuggestionsList';
+export {
+  default as SearchBoxSuggestionsSectionTitle,
+} from './components/SearchBox/styles/SearchBoxSuggestionsSectionTitle';
+export {
+  default as SearchBoxWrapper,
+} from './components/SearchBox/styles/SearchBoxWrapper';
 export { default as SectionTitle } from './components/SectionTitle';
 export { default as Select } from './components/Select';
-export { default as SelectWrapper } from './components/Select/styles/SelectWrapper';
+export {
+  default as SelectWrapper,
+} from './components/Select/styles/SelectWrapper';
 export { default as SidebarList } from './components/SidebarList';
-export { default as SidebarListItem } from './components/SidebarList/SidebarListItem';
-export { default as SidebarListContainer } from './components/SidebarList/styles/SidebarListContainer';
-export { default as SidebarListItemContainer } from './components/SidebarList/styles/SidebarListItemContainer';
-export { default as SidebarListItemDetails } from './components/SidebarList/styles/SidebarListItemDetails';
-export { default as SidebarListItemLabel } from './components/SidebarList/styles/SidebarListItemLabel';
-export { default as SidebarListShowMore } from './components/SidebarList/styles/SidebarListShowMore';
+export {
+  default as SidebarListItem,
+} from './components/SidebarList/SidebarListItem';
+export {
+  default as SidebarListContainer,
+} from './components/SidebarList/styles/SidebarListContainer';
+export {
+  default as SidebarListItemContainer,
+} from './components/SidebarList/styles/SidebarListItemContainer';
+export {
+  default as SidebarListItemDetails,
+} from './components/SidebarList/styles/SidebarListItemDetails';
+export {
+  default as SidebarListItemLabel,
+} from './components/SidebarList/styles/SidebarListItemLabel';
+export {
+  default as SidebarListShowMore,
+} from './components/SidebarList/styles/SidebarListShowMore';
 export { default as Spacing } from './components/Spacing';
 export { default as Steps } from './components/Steps';
 export { default as Step } from './components/Steps/Step';
-export { default as StepContainer } from './components/Steps/styles/StepContainer';
+export {
+  default as StepContainer,
+} from './components/Steps/styles/StepContainer';
 export { default as StepContent } from './components/Steps/styles/StepContent';
 export { default as StepList } from './components/Steps/styles/StepList';
 export { default as StepNumber } from './components/Steps/styles/StepNumber';
@@ -179,19 +339,41 @@ export { default as TableRowDetails } from './components/Table/TableRowDetails';
 export { default as TableWrap } from './components/Table/TableWrap';
 export { default as TableBody } from './components/Table/styles/TableBody';
 export { default as TableCell } from './components/Table/styles/TableCell';
-export { default as TableControlsContainer } from './components/Table/styles/TableControlsContainer';
-export { default as TableControlsIcons } from './components/Table/styles/TableControlsIcons';
-export { default as TableControlsRow } from './components/Table/styles/TableControlsRow';
-export { default as TableHeaderColumnName } from './components/Table/styles/TableHeaderColumnName';
-export { default as TableHeaderSortArrowIcon } from './components/Table/styles/TableHeaderSortArrowIcon';
-export { default as TableHeaderSortArrows } from './components/Table/styles/TableHeaderSortArrows';
-export { default as TableHeaderStyles } from './components/Table/styles/TableHeaderStyles';
-export { default as TableOverlay } from './components/Table/styles/TableOverlay';
+export {
+  default as TableControlsContainer,
+} from './components/Table/styles/TableControlsContainer';
+export {
+  default as TableControlsIcons,
+} from './components/Table/styles/TableControlsIcons';
+export {
+  default as TableControlsRow,
+} from './components/Table/styles/TableControlsRow';
+export {
+  default as TableHeaderColumnName,
+} from './components/Table/styles/TableHeaderColumnName';
+export {
+  default as TableHeaderSortArrowIcon,
+} from './components/Table/styles/TableHeaderSortArrowIcon';
+export {
+  default as TableHeaderSortArrows,
+} from './components/Table/styles/TableHeaderSortArrows';
+export {
+  default as TableHeaderStyles,
+} from './components/Table/styles/TableHeaderStyles';
+export {
+  default as TableOverlay,
+} from './components/Table/styles/TableOverlay';
 export { default as TableRow } from './components/Table/styles/TableRow';
-export { default as TableRowDetailsRow } from './components/Table/styles/TableRowDetailsRow';
-export { default as TableRowDetailsStyles } from './components/Table/styles/TableRowDetailsStyles';
+export {
+  default as TableRowDetailsRow,
+} from './components/Table/styles/TableRowDetailsRow';
+export {
+  default as TableRowDetailsStyles,
+} from './components/Table/styles/TableRowDetailsStyles';
 export { default as TableStyles } from './components/Table/styles/TableStyles';
-export { default as TableWrapShadow } from './components/Table/styles/TableWrapShadow';
+export {
+  default as TableWrapShadow,
+} from './components/Table/styles/TableWrapShadow';
 export { default as Tabs } from './components/Tabs';
 export { default as Tab } from './components/Tabs/styles/Tab';
 export { default as TabContainer } from './components/Tabs/styles/TabContainer';
@@ -200,7 +382,9 @@ export { default as TabList } from './components/Tabs/styles/TabList';
 export { default as TextArea } from './components/TextArea';
 export { default as Toast } from './components/Toast';
 export { default as Toggle } from './components/Toggle';
-export { default as ToggleContainer } from './components/Toggle/styles/ToggleContainer';
+export {
+  default as ToggleContainer,
+} from './components/Toggle/styles/ToggleContainer';
 export { default as ToggleInput } from './components/Toggle/styles/ToggleInput';
 export { default as ToggleLabel } from './components/Toggle/styles/ToggleLabel';
 export { default as childrenWithProps } from './extensions/childrenWithProps';
@@ -208,14 +392,18 @@ export { default as formatMoney } from './extensions/formatMoney';
 export { default as generateId } from './extensions/generateId';
 export { default as parseFlex } from './extensions/parseFlex';
 export { default as provinces } from './extensions/provinces';
-export { default as selectItemPrimaryValue } from './extensions/selectItemPrimaryValue';
+export {
+  default as selectItemPrimaryValue,
+} from './extensions/selectItemPrimaryValue';
 export { default as themeGet } from './extensions/themeGet';
 export { default as layouts } from './layouts';
 export { default as Fields } from './layouts/Fields';
 export { default as Field } from './layouts/Fields/Field';
 export { default as FieldContent } from './layouts/Fields/styles/FieldContent';
 export { default as FieldRow } from './layouts/Fields/styles/FieldRow';
-export { default as FieldRowContainer } from './layouts/Fields/styles/FieldRowContainer';
+export {
+  default as FieldRowContainer,
+} from './layouts/Fields/styles/FieldRowContainer';
 export { default as Flow } from './layouts/Flow';
 export { default as FlowItem } from './layouts/Flow/FlowItem';
 export { default as FlowRow } from './layouts/Flow/FlowRow';
@@ -224,23 +412,39 @@ export { default as FlowCheckbox } from './layouts/Flow/fields/FlowCheckbox';
 export { default as FlowFile } from './layouts/Flow/fields/FlowFile';
 export { default as FlowInput } from './layouts/Flow/fields/FlowInput';
 export { default as FlowMulti } from './layouts/Flow/fields/FlowMulti';
-export { default as FlowRadioGroup } from './layouts/Flow/fields/FlowRadioGroup';
+export {
+  default as FlowRadioGroup,
+} from './layouts/Flow/fields/FlowRadioGroup';
 export { default as FlowSelect } from './layouts/Flow/fields/FlowSelect';
 export { default as FlowTextArea } from './layouts/Flow/fields/FlowTextArea';
 export { default as FlowToggle } from './layouts/Flow/fields/FlowToggle';
-export { default as FlowItemContainer } from './layouts/Flow/styles/FlowItemContainer';
-export { default as FlowItemContent } from './layouts/Flow/styles/FlowItemContent';
-export { default as FlowItemFlexibleContent } from './layouts/Flow/styles/FlowItemFlexibleContent';
-export { default as FlowItemMoreContent } from './layouts/Flow/styles/FlowItemMoreContent';
+export {
+  default as FlowItemContainer,
+} from './layouts/Flow/styles/FlowItemContainer';
+export {
+  default as FlowItemContent,
+} from './layouts/Flow/styles/FlowItemContent';
+export {
+  default as FlowItemFlexibleContent,
+} from './layouts/Flow/styles/FlowItemFlexibleContent';
+export {
+  default as FlowItemMoreContent,
+} from './layouts/Flow/styles/FlowItemMoreContent';
 export { default as FlowRowStyles } from './layouts/Flow/styles/FlowRowStyles';
 export { default as Page } from './layouts/Page';
 export { default as Pane } from './layouts/Pane';
 export { default as PaneColumn } from './layouts/Pane/PaneColumn';
 export { default as PaneRow } from './layouts/Pane/PaneRow';
 export { default as PaneSection } from './layouts/Pane/PaneSection';
-export { default as PaneSectionContent } from './layouts/Pane/styles/PaneSectionContent';
-export { default as PaneSectionTitle } from './layouts/Pane/styles/PaneSectionTitle';
-export { default as PaneSectionWrap } from './layouts/Pane/styles/PaneSectionWrap';
+export {
+  default as PaneSectionContent,
+} from './layouts/Pane/styles/PaneSectionContent';
+export {
+  default as PaneSectionTitle,
+} from './layouts/Pane/styles/PaneSectionTitle';
+export {
+  default as PaneSectionWrap,
+} from './layouts/Pane/styles/PaneSectionWrap';
 export { default as PaneStyles } from './layouts/Pane/styles/PaneStyles';
 export { default as SidebarLayout } from './layouts/SidebarLayout';
 export { default as theme } from './theme';

--- a/src/theme/irisTheme.js
+++ b/src/theme/irisTheme.js
@@ -66,6 +66,7 @@ export const colors = {
     inverted: '#272b2d',
     disabled: '#ececec',
     disabledSelected: '#d2d2d2',
+    dark: '#004658',
   },
   text: {
     default: '#666',

--- a/src/theme/irisTheme.js
+++ b/src/theme/irisTheme.js
@@ -16,6 +16,7 @@ export const colors = {
     light: '#e0fff7',
     border: '#00fbb9',
     dark: '#005c44',
+    medium: '#00aa6c',
   },
   /* aka 'red' */
   negative: {
@@ -23,6 +24,7 @@ export const colors = {
     light: '#ffede8',
     border: '#ffb39e',
     dark: '#a53f0c',
+    medium: '#ff391a',
   },
   accents: [
     /* purple */
@@ -55,17 +57,20 @@ export const colors = {
   graphics: ['#41d3bd', '#a95adf'],
   border: {
     medium: '#c2c2c2',
+    dark: '#004658',
     light: '#e1e1e1',
+    disabled: '#d2d2d2',
   },
   background: {
     default: '#fff',
     inverted: '#272b2d',
-    disabled: '#e1e1e1',
+    disabled: '#ececec',
+    disabledSelected: '#d2d2d2',
   },
   text: {
     default: '#666',
     inverted: '#fff',
-    disabled: '#666',
+    disabled: '#c2c2c2',
   },
 };
 
@@ -83,7 +88,7 @@ export const shadows = {
     0 1px 5px 0 rgba(0, 0, 0, 0.12),
     0 3px 1px -2px rgba(0 ,0, 0, 0.2)
     `,
-  focusOutline: '0 0 0 5px #d9f5fc',
+  focusOutline: '0 0 0 5px #e0f7fd',
 };
 
 export const spacing = {

--- a/tools/styleguide/Wrapper.js
+++ b/tools/styleguide/Wrapper.js
@@ -39,7 +39,7 @@ export default class Wrapper extends React.Component {
   getThemeProvider = () => {
     switch (this.state.theme) {
       case 'catapult':
-        return BandwidthThemeProvider.Catapult;
+        return BandwidthThemeProvider.CatapultThemeProvider;
       default:
         return BandwidthThemeProvider;
     }


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Breaking Changes

* Potentially some minor color changes from changing the Iris theme; this is mostly in changing the disabled colors, which we want to be consistent across the application

## Changes to Existing Components

* Altered `BulkSelect` and `BulkSelectItem` color scheme, in particular when disabled
* `BulkSelectItem` is now a button, which supports disabled behavior unlike `div`

## New Visual Components

* Added new color variant of `BulkSelect`

## Other
* Fixed Catapult theme provider not being set properly
