### PR TITLE
Add new accordion state features

### DIFF
--- a/src/behaviors/ExpandToggle/ExpandToggle.js
+++ b/src/behaviors/ExpandToggle/ExpandToggle.js
@@ -39,6 +39,10 @@ class ExpandToggle extends React.Component {
      */
     startExpanded: PropTypes.bool,
     /**
+     * If true, the user cannot change the state
+     */
+    disabled: PropTypes.bool,
+    /**
      * react-motion config, see https://github.com/chenglou/react-motion#--spring-val-number-config-springhelperconfig--opaqueconfig
      */
     springConfig: PropTypes.shape({
@@ -55,6 +59,7 @@ class ExpandToggle extends React.Component {
     isExpanded: null,
     startExpanded: false,
     springConfig: null,
+    disabled: false,
   };
 
   constructor(props) {
@@ -65,6 +70,10 @@ class ExpandToggle extends React.Component {
   }
 
   handleToggle = () => {
+    if (this.props.disabled) {
+      return;
+    }
+
     if (this.props.onToggle) {
       this.props.onToggle(this.calcIsExpanded());
     }
@@ -82,20 +91,23 @@ class ExpandToggle extends React.Component {
   };
 
   renderToggle = () => {
-    const { toggleContent } = this.props;
+    const { toggleContent, disabled } = this.props;
     if (_.isFunction(toggleContent)) {
-      return toggleContent(this.calcIsExpanded());
+      return toggleContent(this.calcIsExpanded(), disabled);
     }
     return toggleContent;
   };
 
   render() {
     const isExpanded = this.calcIsExpanded();
-    const { children, id, className, springConfig } = this.props;
+    const { children, id, className, springConfig, disabled } = this.props;
 
     return (
       <div id={id} className={className}>
-        <div style={{ cursor: 'pointer' }} onClick={this.handleToggle}>
+        <div
+          style={{ cursor: disabled ? 'auto' : 'pointer' }}
+          onClick={this.handleToggle}
+        >
           {this.renderToggle()}
         </div>
         <Collapse isOpened={isExpanded} springConfig={springConfig}>

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -25,9 +25,15 @@ class Accordion extends React.Component {
      */
     children: PropTypes.node.isRequired,
     /**
-     * Pass isExpanded to override the internal collapsing state
+     * Pass isExpanded to override the internal collapsing state (makes the expanded state a controlled value, please
+     * use onToggle to manage the state yourself or startExpanded if you just want to set the initial state).
      */
     isExpanded: PropTypes.bool,
+    /**
+     * Use this to set the default initial state of the internal expanded state without
+     * turning it into a controlled value.
+     */
+    startExpanded: PropTypes.bool,
     /**
      * DEPRECATED: the negation of isExpanded, overrides internal collapse state
      */
@@ -36,6 +42,11 @@ class Accordion extends React.Component {
      * Add a handler for when the accordion is collapsed or expanded.
      */
     onToggle: PropTypes.func,
+    /**
+     * If true, the user cannot change the expanded state of this
+     * accordion.
+     */
+    disabled: PropTypes.bool,
     /**
      * Set a classname for the accordion container element.
      */
@@ -68,10 +79,12 @@ class Accordion extends React.Component {
 
   static defaultProps = {
     isExpanded: null,
+    startExpanded: false,
     isCollapsed: null,
     onToggle: null,
     className: null,
     id: null,
+    disabled: false,
     Border: AccordionBorder,
     Label: AccordionLabel,
     Arrow: AccordionArrow,
@@ -90,24 +103,35 @@ class Accordion extends React.Component {
     return isExpanded;
   };
 
-  renderLabel = isExpanded => (
-    <this.props.Label onClick={this.handleToggle}>
+  renderLabel = (isExpanded, disabled) => (
+    <this.props.Label disabled={disabled}>
       <this.props.Arrow isExpanded={isExpanded} name="forward" size={21} />
       <this.props.LabelText>{this.props.label}</this.props.LabelText>
     </this.props.Label>
   );
 
   render() {
-    const { id, className, onToggle, children, Border, Content } = this.props;
+    const {
+      id,
+      className,
+      onToggle,
+      children,
+      Border,
+      Content,
+      startExpanded,
+      disabled,
+    } = this.props;
 
     return (
-      <Border>
+      <Border disabled={disabled}>
         <ExpandToggle
           id={id}
           className={className}
           onToggle={onToggle}
           toggleContent={this.renderLabel}
           isExpanded={this.coalesceIsExpandedProps()}
+          startExpanded={startExpanded}
+          disabled={disabled}
         >
           <Content>{children}</Content>
         </ExpandToggle>

--- a/src/components/Accordion/Accordion.md
+++ b/src/components/Accordion/Accordion.md
@@ -5,7 +5,7 @@ Accepts \`label\` to define what's rendered in the label.
 Also exports \`ContentPadding\`, which you can use on any content contained inside the accordion to achieve consistent padding.
 ```javascript
 <Accordion label="Hello">
-  <p>Some content</p>
+  Some content
 </Accordion>
 ```
 
@@ -16,5 +16,33 @@ const Button = require('../Button').default;
 <Accordion.Small label="Small!">
   Some content<br />
   <Button>A normal Button</Button>
+</Accordion.Small>
+```
+
+_Start open_
+```javascript
+<Accordion label="Hello" startExpanded>
+  Some content
+</Accordion>
+```
+
+_Disabled_
+```javascript
+<Accordion label="Disabled" disabled>
+  Content
+</Accordion>
+```
+
+_Disabled, start expanded_
+```javascript
+<Accordion label="Disabled" startExpanded disabled>
+  Visible content
+</Accordion>
+```
+
+_Small disabled_
+```javascript
+<Accordion.Small label="Small disabled" disabled>
+  Some content
 </Accordion.Small>
 ```

--- a/src/components/Accordion/styles/AccordionBorder.js
+++ b/src/components/Accordion/styles/AccordionBorder.js
@@ -5,4 +5,7 @@ export default styled.div`
   border-width: ${get('thicknesses.normal')};
   border-color: ${get('colors.gray.border')};
   border-style: solid;
+
+  background: ${props =>
+    props.disabled ? get('colors.background.disabled')(props) : 'transparent'};
 `;

--- a/src/components/Accordion/styles/AccordionLabel.js
+++ b/src/components/Accordion/styles/AccordionLabel.js
@@ -8,7 +8,7 @@ const AccordionLabel = styled.div`
   font-size: 1.5em;
   text-transform: none;
   font-weight: 400;
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? 'auto' : 'pointer')};
   display: flex;
   flex-direction: row;
   user-select: none;


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* ExpandToggle now supports disabling
* Accordion now supports startExpanded and disabled props
* Visual styling for disabled accordions
* ExpandToggle now passes disabled state to label render prop
