### PR TITLE
Add visual focus forcing prop to Anchor

### DIFF
--- a/src/components/Anchor/Anchor.js
+++ b/src/components/Anchor/Anchor.js
@@ -45,6 +45,14 @@ class Anchor extends React.Component {
      */
     onClick: PropTypes.func,
     /**
+     * Bind a handler for the mouseEnter event
+     */
+    onMouseEnter: PropTypes.func,
+    /**
+     * Bind a handler for the mouseLeave event
+     */
+    onMouseLeave: PropTypes.func,
+    /**
      * whether the contents should be treated as text (underlined),
      * icon (has specific styling), or 'content' (no styling).
      */
@@ -210,6 +218,8 @@ class Anchor extends React.Component {
       icon,
       newTab,
       appearFocused,
+      onMouseEnter,
+      onMouseLeave,
     } = this.props;
     const Component = this.getComponentType();
 
@@ -226,6 +236,8 @@ class Anchor extends React.Component {
             icon={icon}
             newTab={newTab}
             appearFocused={appearFocused}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
           >
             {this.childrenWithProps({ active: !!match })}
           </Component>

--- a/src/components/Anchor/Anchor.js
+++ b/src/components/Anchor/Anchor.js
@@ -70,6 +70,11 @@ class Anchor extends React.Component {
      */
     icon: PropTypes.string,
     /**
+     * This prop can be used to 'pseudo-focus' an anchor visually. Useful when
+     * supporting some advanced keyboard navigation scenarios.
+     */
+    appearFocused: PropTypes.bool,
+    /**
      * Renders a text anchor linking to an external site
      */
     ExternalTextAnchor: PropTypes.func,
@@ -104,6 +109,7 @@ class Anchor extends React.Component {
     className: null,
     id: null,
     newTab: false,
+    appearFocused: false,
     external: undefined,
     ExternalTextAnchor: DefaultExternalTextAnchor,
     ExternalIconAnchor: DefaultExternalIconAnchor,
@@ -195,7 +201,16 @@ class Anchor extends React.Component {
   };
 
   render() {
-    const { to, exact, children, className, id, icon, newTab } = this.props;
+    const {
+      to,
+      exact,
+      children,
+      className,
+      id,
+      icon,
+      newTab,
+      appearFocused,
+    } = this.props;
     const Component = this.getComponentType();
 
     return (
@@ -210,6 +225,7 @@ class Anchor extends React.Component {
             id={id}
             icon={icon}
             newTab={newTab}
+            appearFocused={appearFocused}
           >
             {this.childrenWithProps({ active: !!match })}
           </Component>

--- a/src/components/Anchor/Anchor.md
+++ b/src/components/Anchor/Anchor.md
@@ -110,3 +110,12 @@ _An inverted "combo" anchor_
   <Anchor.Inverted icon="loginRounded">Login</Anchor.Inverted>
 </div>
 ```
+
+_Controlled 'pseudo-focused' state_
+```javascript
+<div>
+  <Anchor appearFocused>Foo</Anchor>
+  <Anchor appearFocused icon="file">Bar</Anchor>
+  <Anchor appearFocused newTab>Baz</Anchor>
+</div>
+```

--- a/src/components/Anchor/styles/ExternalIconAnchor.js
+++ b/src/components/Anchor/styles/ExternalIconAnchor.js
@@ -13,7 +13,7 @@ const iconStyles = css`
   font-weight: 700;
 
   &::after {
-    opacity: 0;
+    opacity: ${({ appearFocused }) => (appearFocused ? 0.125 : 0)};
   }
 
   &::before {

--- a/src/components/Anchor/styles/ExternalTextAnchor.js
+++ b/src/components/Anchor/styles/ExternalTextAnchor.js
@@ -5,6 +5,12 @@ import { base, positive, negative, dark, inverted } from './sharedStyles';
 
 const color = get('colors.primary.alternate');
 
+const focusBeforeStyles = css`
+  right: -1.5em;
+  opacity: 1;
+  transition: right 0.3s ease, opacity 0.2s ease 0.1s;
+`;
+
 const newTabIconStyles = css`
   &::before {
     content: "${icons('openInWindow')}";
@@ -15,12 +21,12 @@ const newTabIconStyles = css`
     right: 0;
     z-index: 1;
     transition: right 0.3s ease, opacity 0.2s ease;
+
+    ${({ appearFocused }) => (appearFocused ? focusBeforeStyles : '')}
   }
 
   &:hover::before {
-    right: -1.5em;
-    opacity: 1;
-    transition: right 0.3s ease, opacity 0.2s ease 0.1s;
+    ${focusBeforeStyles}
   }
 `;
 

--- a/src/components/Anchor/styles/sharedStyles.js
+++ b/src/components/Anchor/styles/sharedStyles.js
@@ -1,6 +1,15 @@
 import { css } from 'styled-components';
 import get from 'extensions/themeGet';
 
+const focusAfterStyles = css`
+  height: calc(100% + 0.2em);
+  width: calc(100% + 0.6em);
+  left: -0.3em;
+  opacity: 0.125;
+  transition: height 0.15s ease, width 0.15s ease, left 0.15s ease,
+    opacity 0s ease;
+`;
+
 const color = get('colors.primary.alternate');
 export const base = css`
   color: ${color};
@@ -33,16 +42,13 @@ export const base = css`
     left: 0;
     transition: height 0.15s ease, width 0.15s ease, left 0.15s ease,
       opacity 0.25s ease;
+
+    ${({ appearFocused }) => (appearFocused ? focusAfterStyles : '')};
   }
 
   &:hover::after,
   &:focus::after {
-    height: calc(100% + 0.2em);
-    width: calc(100% + 0.6em);
-    left: -0.3em;
-    opacity: 0.125;
-    transition: height 0.15s ease, width 0.15s ease, left 0.15s ease,
-      opacity 0s ease;
+    ${focusAfterStyles};
   }
 `;
 


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Added "appearFocused" prop to Anchor to force it to render as if it were focused. Helpful for more advanced accessible UIs.
