### PR TITLE
exclude appearFocused prop from html a tag

### DIFF
--- a/src/components/Anchor/styles/DomSafeLink.js
+++ b/src/components/Anchor/styles/DomSafeLink.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 /**
- * Prevents the `newTab` prop from being passed to Link,
+ * Prevents the `newTab` or `appearFocused` prop from being passed to Link,
  * which emits errors when it receives props it doesn't expect.
  */
-export default ({ newTab, children, ...rest }) => (
+export default ({ newTab, appearFocused, children, ...rest }) => (
   <Link {...rest}>{children}</Link>
 );


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Anchor no longer passes `appearFocused` all the way through, so React won't complain about invalid props on the underlying `<a>` anymore.
