### PR TITLE
Restyle Checkbox

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -20,6 +20,10 @@ export default class Checkbox extends React.Component {
      */
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     /**
+     * Whether the checkbox is checked or not.
+     */
+    checked: PropTypes.bool,
+    /**
      * Whether the checkbox is required for form submission.
      */
     required: PropTypes.bool,
@@ -52,7 +56,8 @@ export default class Checkbox extends React.Component {
   static defaultProps = {
     className: null,
     id: null,
-    value: false,
+    value: undefined,
+    checked: undefined,
     required: false,
     disabled: false,
     description: null,
@@ -60,6 +65,20 @@ export default class Checkbox extends React.Component {
     Input: CheckboxInput,
     Label: CheckboxLabel,
     Container: CheckboxContainer,
+  };
+
+  computeChecked = () => {
+    const { value, checked } = this.props;
+
+    if (typeof checked === 'boolean') {
+      return checked;
+    }
+
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    return undefined;
   };
 
   render() {
@@ -73,9 +92,11 @@ export default class Checkbox extends React.Component {
       Container,
       Input,
       Label,
+      checked,
     } = this.props;
 
     const id = this.props.id || generateId('checkbox');
+    const isChecked = this.computeChecked();
 
     return (
       <Container>
@@ -84,11 +105,11 @@ export default class Checkbox extends React.Component {
           className={className}
           type="checkbox"
           disabled={disabled}
-          checked={!!value}
+          checked={isChecked}
           required={required}
           onChange={onChange}
         />
-        <Label htmlFor={id} active={!!value}>
+        <Label htmlFor={id} active={isChecked}>
           {description}
         </Label>
       </Container>

--- a/src/components/Checkbox/Checkbox.md
+++ b/src/components/Checkbox/Checkbox.md
@@ -1,11 +1,18 @@
 A simple checkbox input.
 
-***Checked checkbox***
-```
-<Checkbox value={true} description="Foo" />
+*Uncontrolled (interactive) checkbox*
+```js
+<div>
+  <Checkbox description="Foo" />
+</div>
 ```
 
-***UnChecked checkbox***
+*Disabled empty checkbox*
+```js
+<Checkbox disabled description="Baz" />
 ```
-<Checkbox description="Bar" />
+
+*Disabled checked checkbox*
+```js
+<Checkbox disabled checked description="Bop" />
 ```

--- a/src/components/Checkbox/styles/CheckboxContainer.js
+++ b/src/components/Checkbox/styles/CheckboxContainer.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
 export default styled.div`
-  display: block;
+  display: inline-block;
   position: relative;
 `;

--- a/src/components/Checkbox/styles/CheckboxLabel.js
+++ b/src/components/Checkbox/styles/CheckboxLabel.js
@@ -4,18 +4,18 @@ import Label from '../../Label';
 import Input from './CheckboxInput';
 import icons from 'components/Icon/icons';
 
-const SIZE = '22px';
-const CHECK_SIZE = '14px';
+const SIZE = '30px';
+const CHECK_SIZE = '21px';
 
 // Builds off the base label
 export default styled(Label)`
-  padding: 0.2em 0 0.2em 2.1em;
+  padding: 5px 0 5px calc(${SIZE} + 10px);
+  min-height: ${SIZE};
+  min-width: ${SIZE};
 
   cursor: pointer;
   position: relative;
   user-select: none;
-
-  font-weight: 200;
 
   /* the check */
   &::before {
@@ -33,6 +33,7 @@ export default styled(Label)`
     transform: translate(-50%, -48%);
     z-index: 1;
     box-sizing: border-box;
+    transition: all 0.2s ease;
   }
 
   /* the box */
@@ -43,7 +44,7 @@ export default styled(Label)`
     border-color: ${get('colors.primary.dark')};
     border-width: ${get('thicknesses.wide')};
     border-style: solid;
-    border-radius: 0.2em;
+    border-radius: 3px;
 
     width: ${SIZE};
     height: ${SIZE};
@@ -55,15 +56,32 @@ export default styled(Label)`
     box-sizing: border-box;
   }
 
-  ${Input}:focus + &::after {
+  ${Input}:hover:not(:disabled) + &::after,
+  ${Input}:focus:not(:disabled) + &::after,
+  ${Input}:active:not(:disabled) + &::after {
     box-shadow: ${get('shadows.focusOutline')};
   }
   ${Input}:checked + &::after {
     background: ${get('colors.primary.dark')};
   }
+
   ${Input}:disabled + & {
-    opacity: 0.5;
-    &::before { opacity: 0.5 }
+    color: ${get('colors.text.disabled')};
+    cursor: default;
+  }
+  ${Input}:disabled + &::after {
+    background: ${get('colors.background.disabled')};
+    border-color: ${get('colors.border.disabled')};
+  }
+  ${Input}:disabled:checked + & {
+    &::after {
+      background: ${get('colors.background.disabledSelected')};
+      border-color: ${get('colors.border.disabled')};
+    }
+
+    &::before {
+      color: ${get('colors.text.disabled')};
+    }
   }
   ${Input}:checked + &::before {
     content: "${icons('checkmark')}";


### PR DESCRIPTION
![gif3](https://user-images.githubusercontent.com/2829772/38625196-eae94588-3d77-11e8-9d6d-d1792c06af93.gif)

## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Breaking Changes

* Checkbox size has changed, this may affect some layouts.
* Checkbox is now inline-block, not block; this may affect some layouts.
* Checkbox now uses the `checked` property. A boolean passed to `value` will still modify the `checked` status, but using `value` for controlling checked state is deprecated and should be removed.

## Changes to Existing Components

* Checkbox now supports hover styling.