### PR TITLE
Add spacing prop support, align spacing on headings to baseline and cap

### DIFF
--- a/src/components/H/H1.js
+++ b/src/components/H/H1.js
@@ -2,22 +2,31 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import get from 'extensions/themeGet';
+import userTextSpacing from 'extensions/userTextSpacing';
 
 import H2 from './H2';
 import H3 from './H3';
 import H4 from './H4';
 import H5 from './H5';
 
-const H1 = styled.h1.withConfig({ displayName: 'H1' })`
+const H1 = styled.h1.withConfig({ displayName: 'H1' }).attrs({
+  spacing: userTextSpacing,
+})`
   color: ${get('colors.primary.default')};
   font-weight: 100;
   font-family: ${get('fonts.brand')};
   font-size: 2.5em;
-  margin: 0;
+  margin: ${props => props.spacing};
+  overflow: hidden;
   padding: 0;
 `;
 
 H1.propTypes = {
+  /**
+   * Specify a CSS value or an object { top, right, bottom, left } to
+   * control the spacing around the heading. Defaults to no space.
+   */
+  spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
    * Adds a class name to the element.
    */
@@ -29,6 +38,7 @@ H1.propTypes = {
 };
 
 H1.defaultProps = {
+  spacing: null,
   className: null,
   id: null,
 };

--- a/src/components/H/H1.md
+++ b/src/components/H/H1.md
@@ -1,3 +1,25 @@
 ```javascript
-<H1>Heading 1</H1>
+<div style={{ padding: '30px' }}>
+  <H1>Heading 1</H1>
+</div>
+```
+
+Headings have customized margins to ensure that adjacent elements align against the cap line and baseline of the upper and lower lines of text.
+
+Supply the `spacing` prop to adjust the margin according to our preset spacing values, or a custom CSS value of your choice (like `auto`).
+
+```javascript
+<div style={{ width: '240px' }}>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+  <H1>
+    Multi-line Heading to test Line Height
+  </H1>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', top: '30px' }} />
+  <H1 spacing="lg">
+    Heading with Spacing Applied
+  </H1>
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', bottom: '30px' }} />
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+</div>
 ```

--- a/src/components/H/H2.js
+++ b/src/components/H/H2.js
@@ -2,18 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import get from 'extensions/themeGet';
+import userTextSpacing from 'extensions/userTextSpacing';
 
-const H2 = styled.h2.withConfig({ displayName: 'H2' })`
+const H2 = styled.h2.withConfig({ displayName: 'H2' }).attrs({
+  spacing: userTextSpacing,
+})`
   color: ${get('colors.text.default')};
   font-weight: 700;
   font-family: ${get('fonts.brand')};
   font-size: 2em;
-  line-height: 1.5em;
-  margin: 0;
+  margin: ${props => props.spacing};
   padding: 0;
 `;
 
 H2.propTypes = {
+  /**
+   * Specify a CSS value or an object { top, right, bottom, left } to
+   * control the spacing around the heading. Defaults to no space.
+   */
+  spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
    * Adds a class name to the element.
    */
@@ -25,6 +32,7 @@ H2.propTypes = {
 };
 
 H2.defaultProps = {
+  spacing: null,
   className: null,
   id: null,
 };

--- a/src/components/H/H2.md
+++ b/src/components/H/H2.md
@@ -1,3 +1,25 @@
 ```javascript
-<H2>Heading 2</H2>
+<div style={{ padding: '30px' }}>
+  <H2>Heading 2</H2>
+</div>
+```
+
+Headings have customized margins to ensure that adjacent elements align against the cap line and baseline of the upper and lower lines of text.
+
+Supply the `spacing` prop to adjust the margin according to our preset spacing values, or a custom CSS value of your choice (like `auto`).
+
+```javascript
+<div style={{ width: '240px' }}>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+  <H2>
+    Multi-line Heading to test Line Height
+  </H2>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+    <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', top: '30px' }} />
+  <H2 spacing="lg">
+    Heading with Spacing Applied
+  </H2>
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', bottom: '30px' }} />
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+</div>
 ```

--- a/src/components/H/H3.js
+++ b/src/components/H/H3.js
@@ -2,19 +2,29 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import get from 'extensions/themeGet';
+import userTextSpacing from 'extensions/userTextSpacing';
 
-const H3 = styled.h3.withConfig({ displayName: 'H3' })`
+const LINE_HEIGHT = 1.25;
+
+const H3 = styled.h3.withConfig({ displayName: 'H3' }).attrs({
+  spacing: userTextSpacing.withLineHeight(LINE_HEIGHT),
+})`
   color: ${get('colors.text.default')};
   font-weight: 300;
   font-family: ${get('fonts.brand')};
   font-size: 1.75em;
-  line-height: 1.25;
+  line-height: ${LINE_HEIGHT};
   letter-spacing: 0;
-  margin: 0;
+  margin: ${props => props.spacing};
   padding: 0;
 `;
 
 H3.propTypes = {
+  /**
+   * Specify a CSS value or an object { top, right, bottom, left } to
+   * control the spacing around the heading. Defaults to no space.
+   */
+  spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
    * Adds a class name to the element.
    */
@@ -26,6 +36,7 @@ H3.propTypes = {
 };
 
 H3.defaultProps = {
+  spacing: null,
   className: null,
   id: null,
 };

--- a/src/components/H/H3.md
+++ b/src/components/H/H3.md
@@ -1,3 +1,25 @@
 ```javascript
-<H3>Heading 3</H3>
+<div style={{ padding: '30px' }}>
+  <H3>Heading 3</H3>
+</div>
+```
+
+Headings have customized margins to ensure that adjacent elements align against the cap line and baseline of the upper and lower lines of text.
+
+Supply the `spacing` prop to adjust the margin according to our preset spacing values, or a custom CSS value of your choice (like `auto`).
+
+```javascript
+<div style={{ width: '240px' }}>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+  <H3>
+    Multi-line Heading to test Line Height
+  </H3>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', top: '30px' }} />
+  <H3 spacing="lg">
+    Heading with Spacing Applied
+  </H3>
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', bottom: '30px' }} />
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+</div>
 ```

--- a/src/components/H/H4.js
+++ b/src/components/H/H4.js
@@ -2,19 +2,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import get from 'extensions/themeGet';
+import userTextSpacing from 'extensions/userTextSpacing';
 
-const H4 = styled.h4.withConfig({ displayName: 'H4' })`
+const H4 = styled.h4.withConfig({ displayName: 'H4' }).attrs({
+  spacing: userTextSpacing,
+})`
   color: ${get('colors.primary.default')};
   font-weight: 900;
   font-family: ${get('fonts.brand')};
   font-size: 1.25em;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  margin: 0;
+  margin: ${props => props.spacing};
   padding: 0;
 `;
 
 H4.propTypes = {
+  /**
+   * Specify a CSS value or an object { top, right, bottom, left } to
+   * control the spacing around the heading. Defaults to no space.
+   */
+  spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
    * Adds a class name to the element.
    */
@@ -26,6 +34,7 @@ H4.propTypes = {
 };
 
 H4.defaultProps = {
+  spacing: null,
   className: null,
   id: null,
 };

--- a/src/components/H/H4.md
+++ b/src/components/H/H4.md
@@ -1,3 +1,25 @@
 ```javascript
-<H4>Heading 4</H4>
+<div style={{ padding: '30px' }}>
+  <H4>Heading 4</H4>
+</div>
+```
+
+Headings have customized margins to ensure that adjacent elements align against the cap line and baseline of the upper and lower lines of text.
+
+Supply the `spacing` prop to adjust the margin according to our preset spacing values, or a custom CSS value of your choice (like `auto`).
+
+```javascript
+<div style={{ width: '240px' }}>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+  <H4>
+    Multi-line Heading to test Line Height
+  </H4>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', top: '30px' }} />
+  <H4 spacing="lg">
+    Heading with Spacing Applied
+  </H4>
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', bottom: '30px' }} />
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+</div>
 ```

--- a/src/components/H/H5.js
+++ b/src/components/H/H5.js
@@ -2,17 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import get from 'extensions/themeGet';
+import userTextSpacing from 'extensions/userTextSpacing';
 
-const H5 = styled.h5.withConfig({ displayName: 'H5' })`
+const H5 = styled.h5.withConfig({ displayName: 'H5' }).attrs({
+  spacing: userTextSpacing,
+})`
   color: ${get('colors.text.default')};
   font-weight: 800;
   font-family: ${get('fonts.brand')};
   font-size: 1.15em;
-  margin: 0;
+  margin: ${props => props.spacing};
   padding: 0;
 `;
 
 H5.propTypes = {
+  /**
+   * Specify a CSS value or an object { top, right, bottom, left } to
+   * control the spacing around the heading. Defaults to no space.
+   */
+  spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
    * Adds a class name to the element.
    */
@@ -24,6 +32,7 @@ H5.propTypes = {
 };
 
 H5.defaultProps = {
+  spacing: null,
   className: null,
   id: null,
 };

--- a/src/components/H/H5.md
+++ b/src/components/H/H5.md
@@ -1,3 +1,25 @@
 ```javascript
-<H5>Heading 5</H5>
+<div style={{ padding: '30px' }}>
+  <H5>Heading 5</H5>
+</div>
+```
+
+Headings have customized margins to ensure that adjacent elements align against the cap line and baseline of the upper and lower lines of text.
+
+Supply the `spacing` prop to adjust the margin according to our preset spacing values, or a custom CSS value of your choice (like `auto`).
+
+```javascript
+<div style={{ width: '240px' }}>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+  <H5>
+    Multi-line Heading to test Line Height
+  </H5>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', top: '30px' }} />
+  <H5 spacing="lg">
+    Heading with Spacing Applied
+  </H5>
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', bottom: '30px' }} />
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+</div>
 ```

--- a/src/extensions/userTextSpacing.js
+++ b/src/extensions/userTextSpacing.js
@@ -1,0 +1,90 @@
+/**
+ * EXPERIMENTAL
+ *
+ * Takes a user's `spacing` prop and converts it into margins
+ * which can be applied to text elements so that they are spaced
+ * from the cap-line and baseline, rather than the element bounds.
+ *
+ * This is accomplished by calculating margin with offsets of
+ * em values to 'dig' into the element a bit to reach the cap and baselines.
+ * These em values are based on visual inspection and would vary
+ * by font.
+ *
+ * Passing props as a whole so that we have access to dynamic theme
+ * information.
+ */
+
+import _ from 'lodash';
+import themeGet from './themeGet';
+
+const getSize = (value, props) => {
+  switch (value.toLowerCase()) {
+    case 'xs':
+    case 'extraSmall':
+      return themeGet('spacing.extraSmall')(props);
+    case 'sm':
+    case 'small':
+      return themeGet('spacing.small')(props);
+    case 'md':
+    case 'medium':
+      return themeGet('spacing.medium')(props);
+    case 'lg':
+    case 'large':
+      return themeGet('spacing.large')(props);
+    case 'xl':
+    case 'extraLarge':
+      return themeGet('spacing.extraLarge')(props);
+    default:
+      return value;
+  }
+};
+
+const userTextSpacingWithLineHeight = lineHeight => props => {
+  const { spacing } = props;
+
+  /* these offset values collapse the outer element boundaries so that
+   * adjacent layout aligns with the cap and baseline of the text inside.
+   *
+   * This logic is a little fuzzy. Offsets of -0.25em and -0.5em work
+   * perfectly for a line height of 1.5, but they start to drift as it gets
+   * smaller or larger, so we further scale the value based on its difference
+   * from 1.5. Experiments suggest this produces reasonably accurate results.
+   */
+  const topOffset = `${lineHeight / -6.0 * (lineHeight / 1.5)}em`;
+  const bottomOffset = `${lineHeight / -3.0 * (lineHeight / 1.5)}em`;
+
+  if (!spacing) {
+    // this is default 'no spacing', will align adjacent elements
+    // to the cap and baseline directly
+    return `${topOffset} 0 ${bottomOffset} 0`;
+  }
+
+  if (_.isPlainObject(spacing)) {
+    const top = _.get(spacing, 'top', 0);
+    const right = _.get(spacing, 'right', 0);
+    const bottom = _.get(spacing, 'bottom', 0);
+    const left = _.get(spacing, 'left', 0);
+
+    return `calc(${topOffset} + ${getSize(top, props)}), ${getSize(
+      right,
+      props,
+    )}, calc(${bottomOffset} + ${getSize(bottom, props)}), ${getSize(
+      left,
+      props,
+    )}`;
+  } else if (_.isString(spacing)) {
+    const size = getSize(spacing, props);
+    return `calc(${topOffset} + ${size}) ${size} calc(${bottomOffset} + ${size}) ${size}`;
+  }
+
+  throw new Error(
+    `Invalid spacing prop value ${spacing}, must be a single CSS value string or object { top, right, bottom, left }`,
+  );
+};
+
+// the default global line height is 1.5
+const userTextSpacing = userTextSpacingWithLineHeight(1.5);
+// allow static access to power functions
+userTextSpacing.withLineHeight = userTextSpacingWithLineHeight;
+
+export default userTextSpacing;


### PR DESCRIPTION
![headings](https://user-images.githubusercontent.com/2829772/39531592-7b859146-4df9-11e8-97df-86f64a3d9a88.png)

Pictured: the red lines are the boundaries of the element relative to other elements on the page. The blue dotted lines are 30px from the red lines.

## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Breaking Changes

* Visual breaking change: Heading margin has been adjusted to collapse down to the baseline and cap line of the text. This may break some layouts.

## Changes to Existing Components

* Added `spacing` prop to all H components, allowing customized spacing relative to the baseline and cap line.
