### PR TITLE
Fixes to text spacing, new default spacing, P component

### DIFF
--- a/docs/design/typography.md
+++ b/docs/design/typography.md
@@ -42,6 +42,34 @@ const FontSizes = withTheme(({theme, name}) =>
   )
 );
 
+const Space = () => (
+  <div>
+    <P>
+      Text components, like <Code>P</Code>, <Code>H1</Code>, and <Code>H2</Code>, support the <Code>spacing</Code> prop. <Code>spacing</Code> provides a dynamic way to specify the margins around a text component in relationship to the cap and base lines of the outer text. Unlike normal CSS margins, which align to the logical top and bottom of the element, the margins calculated by <Code>spacing</Code> will visually align with the text content itself, leading to a more consistent experience for the user.
+    </P>
+
+    <Gutter>
+      <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '100%' }} />
+      <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '100%', position: 'relative', top: '30px' }} />
+      <H1 spacing="lg">
+        Heading with Spacing Applied
+      </H1>
+      <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '100%', position: 'relative', bottom: '30px' }} />
+      <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '100%' }} />
+    </Gutter>
+
+    <Gutter>
+      <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '100%' }} />
+      <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '100%', position: 'relative', top: '30px' }} />
+      <P spacing="lg">
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+      </P>
+      <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '100%', position: 'relative', bottom: '30px' }} />
+      <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '100%' }} />
+    </Gutter>
+  </div>
+);
+
 <div>
   <h2>Brand Typeface</h2>
   <Font name="brand"/>
@@ -49,5 +77,7 @@ const FontSizes = withTheme(({theme, name}) =>
   <FontSizes name="brand" />
   <h2>Monospace Typeface</h2>
   <Font name="monospace"/>
+  <h2>The <Code>spacing</Code> Prop</h2>
+  <Space />
 </div>
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2309,6 +2309,16 @@
         "source-map": "0.5.7"
       }
     },
+    "clean-tag": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clean-tag/-/clean-tag-1.0.4.tgz",
+      "integrity": "sha512-PlYwlA+mfgGLf7NLfNm2KxmjNSNo7gJqDVqf8o4tSphqKQ4ZRYlZeMzh9Op04bl+HRIvxe+lMQMKDHYlR7phpA==",
+      "requires": {
+        "html-tags": "2.0.0",
+        "react": "16.3.1",
+        "styled-system": "2.2.5"
+      }
+    },
     "clean-webpack-plugin": {
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz",
@@ -5998,6 +6008,11 @@
           }
         }
       }
+    },
+    "html-tags": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos="
     },
     "html-webpack-plugin": {
       "version": "2.30.1",
@@ -10804,7 +10819,6 @@
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-16.3.1.tgz",
       "integrity": "sha512-NbkxN9jsZ6+G+ICsLdC7/wUD26uNbvKU/RAxEWgc9kcdKvROt+5d5j2cNQm5PSFTQ4WNGsR3pa4qL2Q0/WSy1w==",
-      "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -13051,6 +13065,14 @@
             "has-flag": "1.0.0"
           }
         }
+      }
+    },
+    "styled-system": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-2.2.5.tgz",
+      "integrity": "sha512-/KJxEzd+mPQxTdr85l7K3b6ac97R4G0M2SlTm9sM48dGkg1CjTIURIvvSV3Y92kE+9GUfrPsG2MpeV8QnmSIQg==",
+      "requires": {
+        "prop-types": "15.6.1"
       }
     },
     "stylis": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "animation-timer": "^1.0.12",
     "change-case": "^3.0.1",
+    "clean-tag": "^1.0.4",
     "dedent": "^0.7.0",
     "functional-easing": "^1.0.8",
     "hex-to-hsl": "^1.0.2",

--- a/src/behaviors/ExpandToggle/FixAuto.js
+++ b/src/behaviors/ExpandToggle/FixAuto.js
@@ -34,7 +34,6 @@ export default function fixAuto(spring, props) {
 
   return (
     <div
-      style={{ visibility: 'hidden', position: 'absolute' }}
       ref={ref => {
         if (ref) {
           // Once it's rendered out, fetch bounds

--- a/src/components/Accordion/styles/AccordionContent.js
+++ b/src/components/Accordion/styles/AccordionContent.js
@@ -10,7 +10,7 @@ const AccordionContent = styled.div`
 
 AccordionContent.Small = styled(AccordionContent)`
   padding: ${get('spacing.large')};
-  padding-top: 0;
+  padding-top: ${get('spacing.extraSmall')};
 `;
 
 export default AccordionContent;

--- a/src/components/H/H1.md
+++ b/src/components/H/H1.md
@@ -11,7 +11,7 @@ Supply the `spacing` prop to adjust the margin according to our preset spacing v
 ```javascript
 <div style={{ width: '240px' }}>
   <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
-  <H1>
+  <H1 spacing="0">
     Multi-line Heading to test Line Height
   </H1>
   <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />

--- a/src/components/H/H2.js
+++ b/src/components/H/H2.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import tag from 'clean-tag';
 import get from 'extensions/themeGet';
 import userTextSpacing from 'extensions/userTextSpacing';
 
-const H2 = styled.h2.withConfig({ displayName: 'H2' }).attrs({
-  spacing: userTextSpacing,
-})`
+const H2 = styled(tag.h2)
+  .withConfig({ displayName: 'H2' })
+  .attrs({
+    spacing: userTextSpacing,
+  })`
   color: ${get('colors.text.default')};
   font-weight: 700;
   font-family: ${get('fonts.brand')};
@@ -18,7 +21,7 @@ const H2 = styled.h2.withConfig({ displayName: 'H2' }).attrs({
 H2.propTypes = {
   /**
    * Specify a CSS value or an object { top, right, bottom, left } or { vertical, horizontal } to
-   * control the spacing around the heading. Defaults to no space.
+   * control the spacing around the heading. Defaults to a large space below the element.
    */
   spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
@@ -32,7 +35,7 @@ H2.propTypes = {
 };
 
 H2.defaultProps = {
-  spacing: null,
+  spacing: { bottom: 'lg' },
   className: null,
   id: null,
 };

--- a/src/components/H/H2.md
+++ b/src/components/H/H2.md
@@ -11,7 +11,7 @@ Supply the `spacing` prop to adjust the margin according to our preset spacing v
 ```javascript
 <div style={{ width: '240px' }}>
   <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
-  <H2>
+  <H2 spacing="0">
     Multi-line Heading to test Line Height
   </H2>
   <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />

--- a/src/components/H/H3.js
+++ b/src/components/H/H3.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import tag from 'clean-tag';
 import get from 'extensions/themeGet';
 import userTextSpacing from 'extensions/userTextSpacing';
 
 const LINE_HEIGHT = 1.25;
 
-const H3 = styled.h3.withConfig({ displayName: 'H3' }).attrs({
-  spacing: userTextSpacing.withLineHeight(LINE_HEIGHT),
-})`
+const H3 = styled(tag.h3)
+  .withConfig({ displayName: 'H3' })
+  .attrs({
+    spacing: userTextSpacing.withLineHeight(LINE_HEIGHT),
+  })`
   color: ${get('colors.text.default')};
   font-weight: 300;
   font-family: ${get('fonts.brand')};
@@ -22,7 +25,7 @@ const H3 = styled.h3.withConfig({ displayName: 'H3' }).attrs({
 H3.propTypes = {
   /**
    * Specify a CSS value or an object { top, right, bottom, left } or { vertical, horizontal } to
-   * control the spacing around the heading. Defaults to no space.
+   * control the spacing around the heading. Defaults to a large space below the element.
    */
   spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
@@ -36,7 +39,7 @@ H3.propTypes = {
 };
 
 H3.defaultProps = {
-  spacing: null,
+  spacing: { bottom: 'lg' },
   className: null,
   id: null,
 };

--- a/src/components/H/H3.md
+++ b/src/components/H/H3.md
@@ -11,7 +11,7 @@ Supply the `spacing` prop to adjust the margin according to our preset spacing v
 ```javascript
 <div style={{ width: '240px' }}>
   <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
-  <H3>
+  <H3 spacing="0">
     Multi-line Heading to test Line Height
   </H3>
   <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />

--- a/src/components/H/H4.js
+++ b/src/components/H/H4.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import tag from 'clean-tag';
 import get from 'extensions/themeGet';
 import userTextSpacing from 'extensions/userTextSpacing';
 
-const H4 = styled.h4.withConfig({ displayName: 'H4' }).attrs({
-  spacing: userTextSpacing,
-})`
+const H4 = styled(tag.h4)
+  .withConfig({ displayName: 'H4' })
+  .attrs({
+    spacing: userTextSpacing,
+  })`
   color: ${get('colors.primary.default')};
   font-weight: 900;
   font-family: ${get('fonts.brand')};
@@ -20,7 +23,7 @@ const H4 = styled.h4.withConfig({ displayName: 'H4' }).attrs({
 H4.propTypes = {
   /**
    * Specify a CSS value or an object { top, right, bottom, left } or { vertical, horizontal } to
-   * control the spacing around the heading. Defaults to no space.
+   * control the spacing around the heading. Defaults to a large space below the element.
    */
   spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
@@ -34,7 +37,7 @@ H4.propTypes = {
 };
 
 H4.defaultProps = {
-  spacing: null,
+  spacing: { bottom: 'lg' },
   className: null,
   id: null,
 };

--- a/src/components/H/H4.md
+++ b/src/components/H/H4.md
@@ -11,7 +11,7 @@ Supply the `spacing` prop to adjust the margin according to our preset spacing v
 ```javascript
 <div style={{ width: '240px' }}>
   <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
-  <H4>
+  <H4 spacing="0">
     Multi-line Heading to test Line Height
   </H4>
   <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />

--- a/src/components/H/H5.js
+++ b/src/components/H/H5.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import tag from 'clean-tag';
 import get from 'extensions/themeGet';
 import userTextSpacing from 'extensions/userTextSpacing';
 
-const H5 = styled.h5.withConfig({ displayName: 'H5' }).attrs({
-  spacing: userTextSpacing,
-})`
+const H5 = styled(tag.h5)
+  .withConfig({ displayName: 'H5' })
+  .attrs({
+    spacing: userTextSpacing,
+  })`
   color: ${get('colors.text.default')};
   font-weight: 800;
   font-family: ${get('fonts.brand')};
@@ -18,7 +21,7 @@ const H5 = styled.h5.withConfig({ displayName: 'H5' }).attrs({
 H5.propTypes = {
   /**
    * Specify a CSS value or an object { top, right, bottom, left } or { vertical, horizontal } to
-   * control the spacing around the heading. Defaults to no space.
+   * control the spacing around the heading. Defaults to a large space below the element.
    */
   spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
@@ -32,7 +35,7 @@ H5.propTypes = {
 };
 
 H5.defaultProps = {
-  spacing: null,
+  spacing: { bottom: 'lg' },
   className: null,
   id: null,
 };

--- a/src/components/H/H5.md
+++ b/src/components/H/H5.md
@@ -11,7 +11,7 @@ Supply the `spacing` prop to adjust the margin according to our preset spacing v
 ```javascript
 <div style={{ width: '240px' }}>
   <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
-  <H5>
+  <H5 spacing="0">
     Multi-line Heading to test Line Height
   </H5>
   <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />

--- a/src/components/P/P.js
+++ b/src/components/P/P.js
@@ -1,30 +1,16 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import tag from 'clean-tag';
-import get from 'extensions/themeGet';
 import userTextSpacing from 'extensions/userTextSpacing';
 
-import H2 from './H2';
-import H3 from './H3';
-import H4 from './H4';
-import H5 from './H5';
-
-const H1 = styled(tag.h1)
-  .withConfig({ displayName: 'H1' })
-  .attrs({
-    spacing: userTextSpacing,
-  })`
-  color: ${get('colors.primary.default')};
-  font-weight: 100;
-  font-family: ${get('fonts.brand')};
-  font-size: 2.5em;
+const P = styled(tag.p).attrs({
+  spacing: userTextSpacing,
+})`
   margin: ${props => props.spacing};
-  overflow: hidden;
-  padding: 0;
+  font-size: 1em;
 `;
 
-H1.propTypes = {
+P.propTypes = {
   /**
    * Specify a CSS value or an object { top, right, bottom, left } or { vertical, horizontal } to
    * control the spacing around the heading. Defaults to a large space below the element.
@@ -40,18 +26,10 @@ H1.propTypes = {
   id: PropTypes.string,
 };
 
-H1.defaultProps = {
+P.defaultProps = {
   spacing: { bottom: 'lg' },
   className: null,
   id: null,
 };
 
-H1.H2 = H2;
-H1.H3 = H3;
-H1.H4 = H4;
-H1.H5 = H5;
-
-/**
- * @component
- */
-export default H1;
+export default P;

--- a/src/components/P/P.md
+++ b/src/components/P/P.md
@@ -1,0 +1,21 @@
+```javascript
+<div style={{ width: '240px' }}>
+  <P>
+    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+  </P>
+</div>
+```
+
+Paragraphs are vertically aligned based on the cap and base lines of the text. They support the `spacing` property, which allows a user to specify custom spacing around the component.
+
+```javascript
+<div style={{ width: '240px' }}>
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', top: '30px' }} />
+  <P spacing="lg">
+    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+  </P>
+  <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '240px', position: 'relative', bottom: '30px' }} />
+  <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '240px' }} />
+</div>
+```

--- a/src/components/P/index.js
+++ b/src/components/P/index.js
@@ -1,0 +1,2 @@
+export { default as P } from './P';
+export { default } from './P';

--- a/src/extensions/userTextSpacing.js
+++ b/src/extensions/userTextSpacing.js
@@ -35,7 +35,12 @@ const getSize = (value, props) => {
     case 'extraLarge':
       return themeGet('spacing.extraLarge')(props);
     default:
-      return value;
+      // if it's a unit string, return it
+      if (isNaN(parseInt(`${value}`, 10))) {
+        return value;
+      }
+      // if the user supplied a number, assume pixels
+      return `${parseInt(`${value}`, 10)}px`;
   }
 };
 
@@ -60,10 +65,10 @@ const userTextSpacingWithLineHeight = lineHeight => props => {
   }
 
   if (_.isPlainObject(spacing)) {
-    const top = _.get(spacing, 'top', _.get(spacing, 'vertical', 0));
-    const right = _.get(spacing, 'right', _.get(spacing, 'horizontal', 0));
-    const bottom = _.get(spacing, 'bottom', _.get(spacing, 'vertical', 0));
-    const left = _.get(spacing, 'left', _.get(spacing, 'horizontal', 0));
+    const top = _.get(spacing, 'top', _.get(spacing, 'vertical', '0px'));
+    const right = _.get(spacing, 'right', _.get(spacing, 'horizontal', '0px'));
+    const bottom = _.get(spacing, 'bottom', _.get(spacing, 'vertical', '0px'));
+    const left = _.get(spacing, 'left', _.get(spacing, 'horizontal', '0px'));
 
     return `calc(${topOffset} + ${getSize(top, props)}) ${getSize(
       right,

--- a/src/index.js
+++ b/src/index.js
@@ -244,6 +244,7 @@ export {
   default as NoteContainer,
 } from './components/Note/styles/NoteContainer';
 export { default as NoteCorner } from './components/Note/styles/NoteCorner';
+export { default as P } from './components/P';
 export { default as Pagination } from './components/Pagination';
 export {
   default as PaginationContainer,
@@ -411,10 +412,15 @@ export {
   default as selectItemPrimaryValue,
 } from './extensions/selectItemPrimaryValue';
 export { default as themeGet } from './extensions/themeGet';
+export { default as userTextSpacing } from './extensions/userTextSpacing';
 export { default as layouts } from './layouts';
 export { default as Fields } from './layouts/Fields';
 export { default as Field } from './layouts/Fields/Field';
 export { default as FieldContent } from './layouts/Fields/styles/FieldContent';
+export {
+  default as FieldHelpText,
+} from './layouts/Fields/styles/FieldHelpText';
+export { default as FieldLabel } from './layouts/Fields/styles/FieldLabel';
 export { default as FieldRow } from './layouts/Fields/styles/FieldRow';
 export {
   default as FieldRowContainer,


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Breaking Changes

* Default spacing has been changed for all heading components. They now have 30px below them by default.

## Changes to Existing Components

* Fix some bugs in the `spacing` prop usage.

## New Visual Components

* New `P` component for paragraphs. Uses the text spacing system.

## Misc

Added spacing demonstration to `Typography` page in the docs.

This will be a major version change to accommodate spacing changes messing up existing layouts.
