### PR TITLE
Add alternate Note color

### DIFF
--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import NoteContainer from './styles/NoteContainer';
 import NoteCorner from './styles/NoteCorner';
+import { defaultProps } from 'recompose';
 
 const Note = ({ children, Container, Corner }) => (
   <Container>
@@ -29,5 +30,9 @@ Note.defaultProps = {
   Container: NoteContainer,
   Corner: NoteCorner,
 };
+
+Note.Alternate = defaultProps({
+  Container: NoteContainer.Alternate,
+})(Note);
 
 export default Note;

--- a/src/components/Note/Note.md
+++ b/src/components/Note/Note.md
@@ -4,3 +4,11 @@ const lipsum = require('lorem-ipsum');
   {lipsum({ count: 4 })}
 </Note>
 ```
+
+```javascript
+const lipsum = require('lorem-ipsum');
+
+<Note.Alternate>
+  {lipsum({ count: 6 })}
+</Note.Alternate>
+```

--- a/src/components/Note/styles/NoteContainer.js
+++ b/src/components/Note/styles/NoteContainer.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import get from 'extensions/themeGet';
+import Corner from './NoteCorner';
 
 const NoteContainer = styled.div`
   background: ${get('colors.background.default')};
@@ -10,6 +11,26 @@ const NoteContainer = styled.div`
   padding-left: 1em;
   min-width: 10em;
   position: relative;
+`;
+
+NoteContainer.Alternate = styled(NoteContainer)`
+  background: ${get('colors.primary.light')};
+  color: ${get('colors.primary.dark')};
+  border-color: ${get('colors.primary.default')};
+
+  & > ${Corner} {
+    border-color: ${get('colors.primary.default')};
+
+    &::before {
+      border-color: ${get('colors.primary.default')} transparent transparent
+        ${get('colors.primary.default')};
+      box-shadow: 0 -1px 0 ${get('colors.primary.default')};
+    }
+    &::after {
+      border-color: ${get('colors.primary.light')} transparent transparent
+        ${get('colors.primary.light')};
+    }
+  }
 `;
 
 export default NoteContainer;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2829772/40511071-9dc40ec0-5f6c-11e8-8846-f9f03f30e0b0.png)

## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Added alternate color style for Note