### PR TITLE
Accordion jump fix

### DIFF
--- a/src/behaviors/ExpandToggle/ExpandToggle.js
+++ b/src/behaviors/ExpandToggle/ExpandToggle.js
@@ -68,6 +68,10 @@ class ExpandToggle extends React.Component {
     unmountClosed: false,
   };
 
+  // shouldComponentUpdate = (nextProps, nextState) => {
+  //   return  !_.isEqual(this.state, nextState);
+  // }
+
   constructor(props) {
     super(props);
     this.state = {
@@ -83,7 +87,7 @@ class ExpandToggle extends React.Component {
     if (this.props.onToggle) {
       this.props.onToggle(this.calcIsExpanded());
     }
-    this.setState({ internalIsExpanded: !this.state.internalIsExpanded });
+    this.setState(state => ({ internalIsExpanded: !state.internalIsExpanded }));
   };
 
   calcIsExpanded = () => {
@@ -124,7 +128,12 @@ class ExpandToggle extends React.Component {
         >
           {this.renderToggle()}
         </div>
-        <CollapseType isOpened={isExpanded} springConfig={springConfig}>
+        {/* {this.state.internalIsExpanded ? children : null} */}
+        <CollapseType
+          hasNestedCollapse
+          isOpened={isExpanded}
+          springConfig={springConfig}
+        >
           {children}
         </CollapseType>
       </div>

--- a/src/behaviors/ExpandToggle/ExpandToggle.js
+++ b/src/behaviors/ExpandToggle/ExpandToggle.js
@@ -68,10 +68,6 @@ class ExpandToggle extends React.Component {
     unmountClosed: false,
   };
 
-  // shouldComponentUpdate = (nextProps, nextState) => {
-  //   return  !_.isEqual(this.state, nextState);
-  // }
-
   constructor(props) {
     super(props);
     this.state = {
@@ -128,7 +124,6 @@ class ExpandToggle extends React.Component {
         >
           {this.renderToggle()}
         </div>
-        {/* {this.state.internalIsExpanded ? children : null} */}
         <CollapseType
           hasNestedCollapse
           isOpened={isExpanded}

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -61,6 +61,14 @@ class Accordion extends React.Component {
      */
     id: PropTypes.string,
     /**
+     * react-motion config, see https://github.com/chenglou/react-motion#--spring-val-number-config-springhelperconfig--opaqueconfig
+     */
+    springConfig: PropTypes.shape({
+      stiffness: PropTypes.number,
+      damping: PropTypes.number,
+      precision: PropTypes.number,
+    }),
+    /**
      * A component to render the border
      */
     Border: PropTypes.func,
@@ -91,6 +99,7 @@ class Accordion extends React.Component {
     id: null,
     disabled: false,
     unmountClosed: false,
+    springConfig: null,
     Border: AccordionBorder,
     Label: AccordionLabel,
     Arrow: AccordionArrow,
@@ -127,6 +136,7 @@ class Accordion extends React.Component {
       startExpanded,
       disabled,
       unmountClosed,
+      springConfig,
     } = this.props;
 
     return (
@@ -140,6 +150,7 @@ class Accordion extends React.Component {
           startExpanded={startExpanded}
           disabled={disabled}
           unmountClosed={unmountClosed}
+          springConfig={springConfig}
         >
           <Content>{children}</Content>
         </ExpandToggle>

--- a/src/components/DragLayer/DragLayer.js
+++ b/src/components/DragLayer/DragLayer.js
@@ -52,10 +52,11 @@ class DragLayer extends React.Component {
   renderPreviewContent = () => {
     const { item } = this.props;
 
-    return React.cloneElement(item.children, {
-      // providing a no-op handle wrapper so the handle is still rendered
-      wrapDragHandle: identity,
-    });
+    return React.Children.map(
+      item.children,
+      child =>
+        child ? React.cloneElement(child, { wrapDragHandle: identity }) : null,
+    );
   };
 
   render() {

--- a/src/layouts/Fields/Field.js
+++ b/src/layouts/Fields/Field.js
@@ -9,7 +9,7 @@ import { get } from 'lodash';
  * A single Field element. **Important:** Field cannot be used on its own. Please use Field
  * within the Fields component. See: [Fields](#!/Fields)
  */
-class Field extends React.PureComponent {
+class Field extends React.Component {
   static propTypes = {
     /**
      * **Automatically supplied within <Fields>**

--- a/src/layouts/Fields/Fields.js
+++ b/src/layouts/Fields/Fields.js
@@ -4,7 +4,7 @@ import FieldRowContainer from './styles/FieldRowContainer';
 import FieldRow from './styles/FieldRow';
 import Field from './Field';
 
-class Fields extends React.PureComponent {
+class Fields extends React.Component {
   static Field = Field;
 
   static propTypes = {


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Added `hasNestedCollapse` prop to use of `react-collapse`. This prop is intended to be used whenever an accordion has another accordion inside of it. However, as far as I can tell, it also fixes some of our weird scrolling issues while not causing any new problems. To be fair, we do have cases where we have nested accordions, but this flag also seems to fix cases where accordions aren't nested. Read more about it [here](https://github.com/nkbt/react-collapse#hasnestedcollapse-proptypesbool-default-false).
* Exposed `springConfig` in Accordion to make it easier to play around with in the docs. We still have some jank when users try to scroll during an accordion animation – one way we can improve that experience is by speeding up the accordion animation speed so that it's less likely to occur.