### PR TITLE
Fix react-router not performing exact matches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandwidth/shared-components",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandwidth/shared-components",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Shared Component Library for Bandwidth React Apps",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Anchor/Anchor.js
+++ b/src/components/Anchor/Anchor.js
@@ -208,6 +208,19 @@ class Anchor extends React.Component {
     }
   };
 
+  isActive(to, match, exact) {
+    let active;
+    if (!exact) {
+      // use the default behavior for non-exact matches
+      active = !!match;
+    } else {
+      // when we expect an exact match, dont allow react-router null
+      // value, additionally verify special chars are used
+      active = match == null ? false : match.url === to;
+    }
+    return active;
+  }
+
   render() {
     const {
       to,
@@ -239,7 +252,9 @@ class Anchor extends React.Component {
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
           >
-            {this.childrenWithProps({ active: !!match })}
+            {this.childrenWithProps({
+              active: this.isActive(to, match, exact),
+            })}
           </Component>
         )}
       />


### PR DESCRIPTION
## PR Checklist

## Changes to Existing Components

Updates to the Anchor component based on the behavior of how react router performs matching. There are two cases in particular that can be problematic when using the `!!match` 

- Programmer intends for an exact match but the match object returns a null match [valid case, see react router documentation on null matches](https://reacttraining.com/react-router/web/api/match/null-matches)
- An exact match but the url contains special characters (e.g. `frame:foo` and `frame:bar` are evaluated as an exact match by react router because the colon is treated as a parameter, causing this to evaluate to true).


