### PR TITLE
add spacing support to anchor

### DIFF
--- a/docs/design/typography.md
+++ b/docs/design/typography.md
@@ -42,6 +42,12 @@ const FontSizes = withTheme(({theme, name}) =>
   )
 );
 
+const BlueLine = (props) =>
+  <div style={{ pointerEvents: 'none', borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '100%', position: 'relative', ...props.style}} />
+
+const RedLine = (props) =>
+  <div style={{ pointerEvents: 'none', background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '100%', ...props.style}} />
+
 const Space = () => (
   <div>
     <P>
@@ -49,23 +55,30 @@ const Space = () => (
     </P>
 
     <Gutter>
-      <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '100%' }} />
-      <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '100%', position: 'relative', top: '30px' }} />
+      <RedLine />
+      <BlueLine style={{top: '30px' }} />
       <H1 spacing="lg">
         Heading with Spacing Applied
       </H1>
-      <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '100%', position: 'relative', bottom: '30px' }} />
-      <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '100%' }} />
+      <BlueLine style={{bottom: '30px' }} />
+      <RedLine />
     </Gutter>
 
     <Gutter>
-      <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '100%' }} />
-      <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '100%', position: 'relative', top: '30px' }} />
+      <RedLine />
+      <BlueLine style={{top: '30px' }} />
       <P spacing="lg">
         Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
       </P>
-      <div style={{ borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '100%', position: 'relative', bottom: '30px' }} />
-      <div style={{ background: 'rgba(255, 0, 0, 0.25)', height: '1px', width: '100%' }} />
+      <BlueLine style={{bottom: '30px' }} />
+      <RedLine />
+    </Gutter>
+    <Gutter>
+      <RedLine />
+      <BlueLine style={{top: '30px' }} />
+      <P spacing="lg">A line with an <Anchor>inline link</Anchor></P>
+      <BlueLine style={{bottom: '30px' }} />
+      <RedLine />
     </Gutter>
   </div>
 );

--- a/src/components/Anchor/Anchor.js
+++ b/src/components/Anchor/Anchor.js
@@ -127,7 +127,7 @@ class Anchor extends React.Component {
     newTab: false,
     appearFocused: false,
     external: undefined,
-    spacing: {},
+    spacing: { horizontal: 'auto' },
     ExternalTextAnchor: DefaultExternalTextAnchor,
     ExternalIconAnchor: DefaultExternalIconAnchor,
     ExternalContentAnchor: DefaultExternalContentAnchor,

--- a/src/components/Anchor/Anchor.js
+++ b/src/components/Anchor/Anchor.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withProps } from 'recompose';
 import { Route } from 'react-router-dom';
+import userSpacing from 'extensions/userSpacing';
+import { withTheme } from 'styled-components';
+
 import DefaultExternalContentAnchor from './styles/ExternalContentAnchor';
 import DefaultExternalIconAnchor from './styles/ExternalIconAnchor';
 import DefaultExternalTextAnchor from './styles/ExternalTextAnchor';
@@ -83,6 +86,11 @@ class Anchor extends React.Component {
      */
     appearFocused: PropTypes.bool,
     /**
+     * Specify a CSS value or an object { top, right, bottom, left } or { vertical, horizontal } to
+     * control the spacing around the heading. Defaults to a large space below the element.
+     */
+    spacing: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    /**
      * Renders a text anchor linking to an external site
      */
     ExternalTextAnchor: PropTypes.func,
@@ -119,6 +127,7 @@ class Anchor extends React.Component {
     newTab: false,
     appearFocused: false,
     external: undefined,
+    spacing: {},
     ExternalTextAnchor: DefaultExternalTextAnchor,
     ExternalIconAnchor: DefaultExternalIconAnchor,
     ExternalContentAnchor: DefaultExternalContentAnchor,
@@ -238,6 +247,7 @@ class Anchor extends React.Component {
             appearFocused={appearFocused}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
+            spacing={userSpacing.text(this.props)}
           >
             {this.childrenWithProps({ active: !!match })}
           </Component>
@@ -247,32 +257,34 @@ class Anchor extends React.Component {
   }
 }
 
-Anchor.Danger = Anchor.Negative = withProps({
+const ThemedAnchor = withTheme(Anchor);
+
+ThemedAnchor.Danger = ThemedAnchor.Negative = withProps({
   ExternalTextAnchor: DefaultExternalTextAnchor.Danger,
   ExternalIconAnchor: DefaultExternalIconAnchor.Danger,
   InternalTextAnchor: DefaultInternalTextAnchor.Danger,
   InternalIconAnchor: DefaultInternalIconAnchor.Danger,
-})(Anchor);
+})(ThemedAnchor);
 
-Anchor.Positive = withProps({
+ThemedAnchor.Positive = withProps({
   ExternalTextAnchor: DefaultExternalTextAnchor.Positive,
   ExternalIconAnchor: DefaultExternalIconAnchor.Positive,
   InternalTextAnchor: DefaultInternalTextAnchor.Positive,
   InternalIconAnchor: DefaultInternalIconAnchor.Positive,
-})(Anchor);
+})(ThemedAnchor);
 
-Anchor.Dark = withProps({
+ThemedAnchor.Dark = withProps({
   ExternalTextAnchor: DefaultExternalTextAnchor.Dark,
   ExternalIconAnchor: DefaultExternalIconAnchor.Dark,
   InternalTextAnchor: DefaultInternalTextAnchor.Dark,
   InternalIconAnchor: DefaultInternalIconAnchor.Dark,
-})(Anchor);
+})(ThemedAnchor);
 
-Anchor.Inverted = withProps({
+ThemedAnchor.Inverted = withProps({
   ExternalTextAnchor: DefaultExternalTextAnchor.Inverted,
   ExternalIconAnchor: DefaultExternalIconAnchor.Inverted,
   InternalTextAnchor: DefaultInternalTextAnchor.Inverted,
   InternalIconAnchor: DefaultInternalIconAnchor.Inverted,
-})(Anchor);
+})(ThemedAnchor);
 
-export default Anchor;
+export default ThemedAnchor;

--- a/src/components/Anchor/styles/ExternalIconAnchor.js
+++ b/src/components/Anchor/styles/ExternalIconAnchor.js
@@ -8,7 +8,6 @@ import { base, positive, negative, dark, inverted } from './sharedStyles';
 
 const iconStyles = css`
   text-decoration: none;
-  display: inline-block;
   text-transform: uppercase;
   font-weight: 700;
 

--- a/src/components/Anchor/styles/sharedStyles.js
+++ b/src/components/Anchor/styles/sharedStyles.js
@@ -21,7 +21,8 @@ export const base = css`
   white-space: nowrap;
   position: relative;
   height: auto;
-  margin: auto;
+  display: inline-block;
+  margin: ${props => props.spacing};
 
   &:focus {
     outline: none;

--- a/src/components/Anchor/styles/sharedStyles.js
+++ b/src/components/Anchor/styles/sharedStyles.js
@@ -2,7 +2,7 @@ import { css } from 'styled-components';
 import get from 'extensions/themeGet';
 
 const focusAfterStyles = css`
-  height: calc(100% + 0.2em);
+  height: 100%;
   width: calc(100% + 0.6em);
   left: -0.3em;
   opacity: 0.125;
@@ -39,7 +39,7 @@ export const base = css`
     height: 1px;
     width: 100%;
     position: absolute;
-    bottom: -0.1em;
+    bottom: 0;
     left: 0;
     transition: height 0.15s ease, width 0.15s ease, left 0.15s ease,
       opacity 0.25s ease;


### PR DESCRIPTION
# Anchor Spacing
![anchorspacing](https://user-images.githubusercontent.com/3961037/40848115-3fc1416e-658c-11e8-99aa-3f45d3b87240.png)

## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* The `Anchor` component now supports a `spacing` prop to control spacing to it. I elected to have a default of zero spacing because anchors are commonly used within other elements (paragraphs, buttons, etc.)

Image comparisons are included below - they are very close (the new version ends up on full pixel values instead of decimal pixel values).

## Old Sizes
![oldanchorsize](https://user-images.githubusercontent.com/3961037/40848149-5605bacc-658c-11e8-9179-1f9acd336bf8.png)
![oldanchorfocusedsize](https://user-images.githubusercontent.com/3961037/40848152-57e5387c-658c-11e8-9910-357864296400.png)

## New Sizes
![newanchorsize](https://user-images.githubusercontent.com/3961037/40848162-5f024352-658c-11e8-964e-fb8ed2b6d3a1.png)
![newanchorfocusedsize](https://user-images.githubusercontent.com/3961037/40848166-62376c64-658c-11e8-8950-2b14bed0c030.png)
