### PR TITLE
Fix field customization, allow arbitrary nodes in label and helptext

### DIFF
--- a/src/layouts/Fields/Field.js
+++ b/src/layouts/Fields/Field.js
@@ -96,19 +96,17 @@ class Field extends React.Component {
 
     const labelFor = get(children, 'props.id', null);
 
+    const labelProps = {
+      disabled,
+      required,
+      htmlFor: labelFor,
+      style: this.stylesFor('label'),
+    };
+
     if (typeof label === 'string') {
-      return (
-        <Label
-          disabled={disabled}
-          required={required}
-          htmlFor={labelFor}
-          style={this.stylesFor('label')}
-        >
-          {label}
-        </Label>
-      );
+      return <Label {...labelProps}>{label}</Label>;
     }
-    return React.cloneElement(label, { htmlFor: labelFor });
+    return React.cloneElement(label, labelProps);
   };
 
   renderHelpText = () => {
@@ -118,10 +116,14 @@ class Field extends React.Component {
       return null;
     }
 
+    const helpTextProps = {
+      style: this.stylesFor('helpText'),
+    };
+
     if (typeof helpText === 'string') {
-      return <HelpText style={this.stylesFor('helpText')}>{helpText}</HelpText>;
+      return <HelpText {...helpTextProps}>{helpText}</HelpText>;
     }
-    return helpText;
+    return React.cloneElement(helpText, helpTextProps);
   };
 
   render() {

--- a/src/layouts/Fields/Fields.md
+++ b/src/layouts/Fields/Fields.md
@@ -106,6 +106,25 @@ const longText = new Array(64).fill('Text').join(' ');
 </Fields>
 ```
 
+### Providing customized label and helpText
+
+```js
+const Input = require('../../components/Input').default;
+const Accordion = require('../../components/Accordion').default;
+
+<Fields columns={1}>
+  <Fields.Field
+    label={<i>This is a customized label</i>}
+    helpText={<Accordion.Small label="A very customized helptext">This probably isn't your use-case</Accordion.Small>}
+  >
+    <Input />
+  </Fields.Field>
+  <Fields.Field label="Just a regular field">
+    <Input />
+  </Fields.Field>
+</Fields>
+```
+
 ### Error test: a field which is too wide for the fieldset
 
 This layout should fail with an error in the console explaining that the field is too wide.

--- a/src/layouts/Fields/styles/FieldRow.js
+++ b/src/layouts/Fields/styles/FieldRow.js
@@ -18,8 +18,8 @@ const copyArea = (input, times) =>
 const hasLabel = children =>
   React.Children.toArray(children).some(
     child =>
-      child.props.Label != null &&
-      child.props.label != null &&
+      child.props.Label !== null &&
+      child.props.label !== null &&
       (typeof child.props.label !== 'string' || child.props.label.length > 0),
   );
 
@@ -27,8 +27,8 @@ const hasLabel = children =>
 const hasHelpText = children =>
   React.Children.toArray(children).some(
     child =>
-      child.props.HelpText != null &&
-      child.props.helpText != null &&
+      child.props.HelpText !== null &&
+      child.props.helpText !== null &&
       (typeof child.props.label !== 'string' ||
         child.props.helpText.length > 0),
   );

--- a/src/layouts/Fields/styles/FieldRow.js
+++ b/src/layouts/Fields/styles/FieldRow.js
@@ -20,7 +20,7 @@ const hasLabel = children =>
     child =>
       child.props.Label != null &&
       child.props.label != null &&
-      child.props.label.length > 0,
+      (typeof child.props.label !== 'string' || child.props.label.length > 0),
   );
 
 // Returns true if at least one child uses help text
@@ -29,7 +29,8 @@ const hasHelpText = children =>
     child =>
       child.props.HelpText != null &&
       child.props.helpText != null &&
-      child.props.helpText.length > 0,
+      (typeof child.props.label !== 'string' ||
+        child.props.helpText.length > 0),
   );
 
 /*


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Bugfix: FieldRow no longer omits rows for label or helptext if they are not strings
* Bugfix: Field now adds all required props to arbitrary nodes passed to label or helpText
