### PR TITLE
Fix toggle name prop, standardize toggle value/checked usage

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -81,6 +81,17 @@ export default class Checkbox extends React.PureComponent {
     return undefined;
   };
 
+  computeValue = () => {
+    const { value, checked } = this.props;
+    // assume user is using value correctly if checked is defined
+    // or if value isn't boolean
+    if (checked !== undefined || typeof value !== 'boolean') {
+      return value;
+    }
+
+    return undefined;
+  };
+
   render() {
     const {
       className,
@@ -108,6 +119,7 @@ export default class Checkbox extends React.PureComponent {
           type="checkbox"
           disabled={disabled}
           checked={isChecked}
+          value={this.computeValue()}
           required={required}
           onChange={onChange}
         />

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -16,9 +16,15 @@ class Toggle extends React.PureComponent {
      */
     id: PropTypes.string,
     /**
-     * The value of the toggle.
+     * The value of the toggle. DEPRECATION WARNING: this prop
+     * used to be used for the 'checked' boolean state. You should use
+     * `checked` for that instead.
      */
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    /**
+     * Whether the toggle is 'on' or 'off'.
+     */
+    checked: PropTypes.bool,
     /**
      * Whether the toggle is required for form submission.
      */
@@ -27,6 +33,10 @@ class Toggle extends React.PureComponent {
      * Whether the user is prevented from interacting with the toggle.
      */
     disabled: PropTypes.bool,
+    /**
+     * Adds a name to the underlying input.
+     */
+    name: PropTypes.string,
     /**
      * A description to display next to the toggle.
      */
@@ -53,6 +63,7 @@ class Toggle extends React.PureComponent {
     className: null,
     id: null,
     value: false,
+    name: null,
     required: false,
     disabled: false,
     description: null,
@@ -64,13 +75,37 @@ class Toggle extends React.PureComponent {
 
   defaultId = generateId('toggle');
 
+  computeChecked = () => {
+    const { value, checked } = this.props;
+
+    if (typeof checked === 'boolean') {
+      return checked;
+    }
+
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    return undefined;
+  };
+
+  computeValue = () => {
+    const { value, checked } = this.props;
+    // assume user is using value correctly if checked is defined
+    // or if value isn't boolean
+    if (checked !== undefined || typeof value !== 'boolean') {
+      return value;
+    }
+
+    return undefined;
+  };
+
   render() {
     const {
       className,
-      name,
       disabled,
-      value,
       required,
+      name,
       description,
       onChange,
       Container,
@@ -83,9 +118,11 @@ class Toggle extends React.PureComponent {
         <Input
           id={id}
           className={className}
+          name={name}
           type="checkbox"
           disabled={disabled}
-          checked={!!value}
+          checked={this.computeChecked()}
+          value={this.computeValue()}
           required={required}
           onChange={onChange}
         />

--- a/src/components/Toggle/Toggle.md
+++ b/src/components/Toggle/Toggle.md
@@ -1,8 +1,15 @@
+_Uncontrolled (interactive) toggle_
 ```javascript
 <div>
-  <Toggle value={true} description="On" />
-  <Toggle value={false} description="Off" />
-  <Toggle disabled description="Disabled" />
-  <Toggle value={true} disabled description="Disabled, on" />
+  <Toggle value="foo" description="Foo" />
+</div>
+```
+
+```javascript
+<div>
+  <Toggle checked value="foo" description="On" />
+  <Toggle checked={false} value="bar" description="Off" />
+  <Toggle disabled value="baz" description="Disabled" />
+  <Toggle checked disabled value="corge" description="Disabled, on" />
 </div>
 ```


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Added `name` prop for Toggle, made Toggle's `checked` prop available, made Toggle selectively choose between `value` (legacy) and `checked` for boolean value, made supplying string to `value` work for standardized usage.
* Also made Checkbox consistent with above.
