### PR TITLE
removed webkit scrollbar styles

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -55,21 +55,6 @@ const bootstrapFromTheme = theme => {
       font-weight: normal;
       font-style: normal;
     }
-
-    /* scrollbars */
-
-    ::-webkit-scrollbar {
-      width: 0.5em;
-      height: 0.5em;
-    }
-
-    ::-webkit-scrollbar-thumb {
-      background: rgba(0, 0, 0, 0.25);
-    }
-
-    ::-webkit-scrollbar-track {
-      background: #f3f3f3;
-    }
   `;
 };
 

--- a/src/components/Accordion/styles/AccordionGroupContainer.js
+++ b/src/components/Accordion/styles/AccordionGroupContainer.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import AccordionBorder from './AccordionBorder';
 
 export default styled.div`
-  & > ${AccordionBorder}:not(:first-child) {
+  & > ${AccordionBorder} + ${AccordionBorder} {
     border-top: none;
   }
 `;

--- a/src/components/BandwidthProvider/styles/global.js
+++ b/src/components/BandwidthProvider/styles/global.js
@@ -37,18 +37,4 @@ injectGlobal`
     font-style: normal;
   }
 
-  /* scrollbars */
-
-  ::-webkit-scrollbar {
-    width: 0.5em;
-    height: 0.5em;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.25);
-  }
-
-  ::-webkit-scrollbar-track {
-    background: #f3f3f3;
-  }
 `;

--- a/src/components/SidebarList/styles/SidebarListContainer.js
+++ b/src/components/SidebarList/styles/SidebarListContainer.js
@@ -7,12 +7,4 @@ export default styled.ul`
   list-style-type: none;
   margin: 0;
   padding: 0;
-
-  &::-webkit-scrollbar-thumb {
-    background: ${get('colors.gray.light')};
-  }
-
-  &::-webkit-scrollbar-track {
-    background: ${get('colors.gray.dark')};
-  }
 `;

--- a/tools/styleguide/ComponentsList.js
+++ b/tools/styleguide/ComponentsList.js
@@ -2,9 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ExpandToggle } from '../../src';
 import styled from 'styled-components';
-import Accordion, { AccordionGroup } from 'components/Accordion';
+import Accordion, {
+  AccordionGroup,
+  AccordionBorder,
+} from 'components/Accordion';
 import RadioGroupButtonLabel from 'components/RadioGroup/styles/RadioGroupButtonLabel';
 import get from 'extensions/themeGet';
+
+const CustomBorder = styled(AccordionBorder)`
+  border-left-width: 0;
+  border-right-width: 0;
+`;
 
 const List = styled.ul`
   display: flex;
@@ -55,7 +63,7 @@ export default class ComponentsListRenderer extends React.Component {
     );
 
   renderTopLevel = ({ name, content, sections, components }) => (
-    <Accordion.Small key={name} label={name}>
+    <Accordion.Small key={name} label={name} Border={CustomBorder}>
       {(sections.length > 0 ? sections : components).map(this.renderSection)}
     </Accordion.Small>
   );

--- a/tools/styleguide/StyleGuideRenderer.js
+++ b/tools/styleguide/StyleGuideRenderer.js
@@ -18,9 +18,9 @@ const Sidebar = styled.div`
   grid-area: sidebar;
   background-color: white;
   overflow-y: scroll;
-  border: 1px;
+  border-width: 0 ${get('thicknesses.normal')} 0 0;
   border-style: solid;
-  border-color: ${get('colors.border.light')};
+  border-color: ${get('colors.border.medium')};
 `;
 
 const Content = styled.main`


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

* We now use default webkit scrollbars instead of overriding them. See #142.