### PR TITLE
Sidebar List Item colors

### DIFF
--- a/src/components/SidebarList/styles/SidebarListItemContainer.js
+++ b/src/components/SidebarList/styles/SidebarListItemContainer.js
@@ -6,10 +6,7 @@ export default styled.li`
     props.active
       ? get('colors.gray.light')(props)
       : get('colors.background.default')(props)};
-  color: ${props =>
-    props.active
-      ? get('colors.primary.default')(props)
-      : get('colors.text.default')(props)};
+  color: ${get('colors.text.default')};
   padding: ${get('spacing.medium')} ${get('spacing.large')};
   border-bottom: ${get('thicknesses.normal')} solid
     ${get('colors.border.light')};

--- a/src/components/SidebarList/styles/SidebarListItemContainer.js
+++ b/src/components/SidebarList/styles/SidebarListItemContainer.js
@@ -9,12 +9,12 @@ export default styled.li`
   color: ${get('colors.text.default')};
   padding: ${get('spacing.medium')} ${get('spacing.large')};
   border-bottom: ${get('thicknesses.normal')} solid
-    ${get('colors.border.light')};
+    ${get('colors.border.medium')};
   border-right: ${get('thicknesses.normal')} solid
     ${props =>
       props.active
         ? get('colors.gray.light')(props)
-        : get('colors.border.light')(props)};
+        : get('colors.border.medium')(props)};
   position: relative;
   overflow-x: visible;
   z-index: 100;


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components
* Sidebar list items use medium border color instead of light
* Active sidebar items are no longer blue