### PR TITLE
Radio button disable/focus/hover states

### DIFF
--- a/src/components/RadioGroup/RadioButton.js
+++ b/src/components/RadioGroup/RadioButton.js
@@ -130,7 +130,7 @@ export default class RadioButton extends React.Component {
     const id = this.props.id || `radio-${name}>${value}`;
 
     return (
-      <Container>
+      <Container className={disabled && 'disabled'}>
         <Input
           type="radio"
           id={id}

--- a/src/components/RadioGroup/RadioButton.md
+++ b/src/components/RadioGroup/RadioButton.md
@@ -15,8 +15,37 @@ To join RadioButtons together, use them like you would any `<input type="radio">
   <RadioButton name="example" value="one" label="one" />
   <RadioButton name="example" value="two" label="two" />
   <RadioButton name="example" value="three" label="three" />
-  <RadioButton name="example" value="four" label="four">
-    With extra content
+  <RadioButton name="example" value="four" label="four"/>
+</RadioButton.Group>
+```
+
+_Description_
+```js
+const lipsum = require('lorem-ipsum');
+<RadioButton.Group>
+  <RadioButton name="example2" value="one2" label="description #1">
+    {lipsum({count: 3})}
   </RadioButton>
+  <RadioButton disabled name="example2" value="two2" label="description #2">
+    {lipsum({count: 3})}
+  </RadioButton>
+</RadioButton.Group>
+```
+
+_Small_
+```js
+<RadioButton.Group>
+  <RadioButton.Small name="example3" value="one3" label="one" />
+  <RadioButton.Small name="example3" value="two3" label="two" />
+  <RadioButton.Small name="example3" value="three3" label="three" />
+</RadioButton.Group>
+```
+
+_Disabled_
+```js
+<RadioButton.Group>
+  <RadioButton disabled checked name="example5" value="one5" label="one" />
+  <RadioButton disabled name="example5" value="two5" label="two" />
+  <RadioButton disabled name="example5" value="three5" label="three" />
 </RadioButton.Group>
 ```

--- a/src/components/RadioGroup/styles/RadioGroupButtonContainer.js
+++ b/src/components/RadioGroup/styles/RadioGroupButtonContainer.js
@@ -5,22 +5,20 @@ export default styled.div`
   position: relative;
 
   &:first-of-type > label {
-    border-radius: 3px 0 0 3px;
-  }
-
-  &:first-of-type > label::after {
-    border-radius: 0 0 0 3px;
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
   }
 
   &:last-of-type > label {
-    border-radius: 0 3px 3px 0;
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
   }
 
-  &:last-of-type > label::after {
-    border-radius: 0 0 3px 0;
-  }
-
-  &:not(:first-of-type) > label {
+  &:not(.disabled) + & > label {
     border-left: 0;
+  }
+
+  &.disabled:not(:last-of-type) > label {
+    border-right: 0;
   }
 `;

--- a/src/components/RadioGroup/styles/RadioGroupButtonLabel.js
+++ b/src/components/RadioGroup/styles/RadioGroupButtonLabel.js
@@ -6,7 +6,7 @@ const RadioGroupButtonLabel = styled.label`
   border-width: ${get('thicknesses.thick')};
   border-style: solid;
   border-color: ${get('colors.primary.dark')};
-  padding: 1em 1.4em;
+  padding: 1em;
   cursor: pointer;
   position: relative;
   display: flex;
@@ -14,74 +14,68 @@ const RadioGroupButtonLabel = styled.label`
   align-content: flex-start;
   background: ${get('colors.background.default')};
   color: ${get('colors.primary.dark')};
-  transition: opacity 0.2s ease, background 0.2s ease, color 0.2s ease;
+  transition: opacity 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
   text-transform: uppercase;
   font-weight: bold;
   font-size: 1em;
   height: 100%;
+  min-width: 53px;
+  box-shadow: inset 0 0 0 ${get('colors.primary.default')};
 
-  &::after {
-    content: '';
-    background: ${get('colors.primary.default')};
-    height: 0;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    display: block;
-    transition: height 0.2s ease, opacity 0.2s ease;
+  ${Input}:not(:checked):focus:not(:disabled) + &,
+  ${Input}:not(:checked):hover:not(:disabled) + & {
+    z-index: 3;
   }
 
   ${Input}:focus:not(:disabled) + &,
+  ${Input}:hover:not(:disabled) + &,
   ${Input}:active:not(:disabled) + & {
-    box-shadow: ${get('shadows.focusOutline')};
-  }
-
-  ${Input}:hover:not(:disabled):not(:checked) + &,
-  ${Input}:focus:not(:disabled):not(:checked) + & {
-    &::after {
-      height: 5px;
-      opacity: 0.5;
+    &::before {
+      content: '';
+      box-shadow: ${get('shadows.focusOutline')};
+      position: absolute;
+      bottom: -2px;
+      left: -2px;
+      right: -2px;
+      top: -2px;
+      z-index: 2;
+      border-radius: 3px;
     }
-  }
-
-  ${Input}:checked:hover:not(:disabled) + & {
   }
 
   ${Input}:checked + & {
-    opacity: 1;
     background: ${get('colors.primary.dark')};
     color: ${get('colors.text.inverted')};
-    &::after {
-      height: 5px;
-    }
+    box-shadow: inset 0 -5px 0 ${get('colors.primary.default')};
+    z-index: 1;
   }
 
   ${Input}:disabled + & {
-    color: ${get('colors.text.default')};
-    opacity: 0.5;
-    background-color: ${get('colors.gray.disabled')};
-    border-color: ${get('colors.border.medium')};
-    cursor: auto;
-    &::after {
-      background: ${get('colors.gray.border')};
-    }
+    z-index; -1;
+    cursor: default;
+    color: ${get('colors.text.disabled')};
+    background-color: ${get('colors.background.disabled')};
+    border-color: ${get('colors.border.disabled')};
+  }
+  ${Input}:checked:disabled + & {
+    color: ${get('colors.text.inverted')};
+    background-color: ${get('colors.background.disabledSelected')};
+    box-shadow: inset 0 -5px 0 ${get('colors.background.disabled')};
   }
 `;
 
 RadioGroupButtonLabel.Small = styled(RadioGroupButtonLabel)`
   font-size: 0.8em;
-  padding: 0.83em 1em;
+  padding: 5px 10px;
   font-weight: normal;
 
-  ${Input}:hover + &::after,
-  ${Input}:checked + &::after {
-    height: 2px;
+  ${Input}:checked + & {
+    box-shadow: inset 0 -4px 0 ${get('colors.primary.default')};
   }
-`;
 
-RadioGroupButtonLabel.Large = styled(RadioGroupButtonLabel)`
-  padding: ${get('spacing.large')};
+  ${Input}:checked:disabled + & {
+    box-shadow: inset 0 -4px 0 ${get('colors.background.disabled')};
+  }
 `;
 
 export default RadioGroupButtonLabel;


### PR DESCRIPTION

![jun-18-2018 14-27-25](https://user-images.githubusercontent.com/3961037/41555263-2e72d4a0-7305-11e8-92a8-26c79e4e0b0c.gif)
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Hover state no longer uses blue inset; instead, we use the blue shadow around the border
* Improved z-indexing of elements (hover > selected > normal > disabled)
* Improved disabled states for Radio buttons

