### PR TITLE
sidebar list item font size is now 14px

### DIFF
--- a/src/components/SidebarList/styles/SidebarListItemContainer.js
+++ b/src/components/SidebarList/styles/SidebarListItemContainer.js
@@ -17,5 +17,4 @@ export default styled.li`
         : get('colors.border.medium')(props)};
   position: relative;
   overflow-x: visible;
-  z-index: 100;
 `;

--- a/src/components/SidebarList/styles/SidebarListItemLabel.js
+++ b/src/components/SidebarList/styles/SidebarListItemLabel.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 export default styled.h3`
   text-transform: uppercase;
+  font-size: 14px;
   font-weight: bold;
   margin: 0;
 `;


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Font size of sidebar list items should be 14px

