### PR TITLE
Disabled color fixes for checkboxes and field labels

### DIFF
--- a/src/components/Checkbox/styles/CheckboxLabel.js
+++ b/src/components/Checkbox/styles/CheckboxLabel.js
@@ -80,7 +80,7 @@ export default styled.label`
     }
 
     &::before {
-      color: ${get('colors.text.disabled')};
+      color: ${get('colors.text.inverted')};
     }
   }
   ${Input}:checked + &::before {

--- a/src/components/Label/Label.js
+++ b/src/components/Label/Label.js
@@ -16,10 +16,11 @@ const Label = styled.label.withConfig({ displayName: 'Label' }).attrs({
   line-height: 1.5;
   display: block;
   margin: ${props => props.spacing};
-
-  ${({ disabled }) => (disabled ? 'opacity: 0.5;' : '')} &:disabled {
-    opacity: 0.5;
-  }
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      color: ${get('colors.text.disabled')};
+    `};
 
   ${({ required }) =>
     required


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Disabled check color changed to white
* Disabled labels are now 100% opacity #c2c2c2
