### PR TITLE
Change isActive to be configurable

### DIFF
--- a/src/components/Anchor/Anchor.js
+++ b/src/components/Anchor/Anchor.js
@@ -29,6 +29,19 @@ const inferType = children => {
   return 'wrap';
 };
 
+const matchReactRouter = (to, match, exact) => {
+  let active;
+  if (!exact) {
+    // use the default behavior for non-exact matches
+    active = !!match;
+  } else {
+    // when we expect an exact match, dont allow react-router null
+    // value, additionally verify special chars are used
+    active = match == null ? false : match.url === to;
+  }
+  return active;
+};
+
 class Anchor extends React.Component {
   static propTypes = {
     /**
@@ -119,6 +132,11 @@ class Anchor extends React.Component {
      * Renders a content (image, element) anchor linking to a page in-app
      */
     InternalContentAnchor: PropTypes.func,
+    /**
+     * Resolves whether a link is active. Specifying custom rules for whether
+     * a link is active may be necessary when using custom onClick logic
+     */
+    isActive: PropTypes.func,
   };
 
   static defaultProps = {
@@ -140,6 +158,7 @@ class Anchor extends React.Component {
     InternalTextAnchor: DefaultInternalTextAnchor,
     InternalIconAnchor: DefaultInternalIconAnchor,
     InternalContentAnchor: DefaultInternalContentAnchor,
+    isActive: matchReactRouter,
   };
 
   isExternal = () => {
@@ -228,19 +247,6 @@ class Anchor extends React.Component {
     }
   };
 
-  isActive(to, match, exact) {
-    let active;
-    if (!exact) {
-      // use the default behavior for non-exact matches
-      active = !!match;
-    } else {
-      // when we expect an exact match, dont allow react-router null
-      // value, additionally verify special chars are used
-      active = match == null ? false : match.url === to;
-    }
-    return active;
-  }
-
   render() {
     const {
       to,
@@ -254,6 +260,7 @@ class Anchor extends React.Component {
       onMouseEnter,
       onMouseLeave,
       disabled,
+      isActive,
     } = this.props;
     const Component = this.getComponentType();
 
@@ -276,7 +283,7 @@ class Anchor extends React.Component {
             spacing={userSpacing.text(this.props)}
           >
             {this.childrenWithProps({
-              active: this.isActive(to, match, exact),
+              active: isActive(to, match, exact),
             })}
           </Component>
         )}

--- a/src/components/Anchor/Anchor.js
+++ b/src/components/Anchor/Anchor.js
@@ -158,7 +158,7 @@ class Anchor extends React.Component {
     InternalTextAnchor: DefaultInternalTextAnchor,
     InternalIconAnchor: DefaultInternalIconAnchor,
     InternalContentAnchor: DefaultInternalContentAnchor,
-    isActive: matchReactRouter,
+    active: matchReactRouter,
   };
 
   isExternal = () => {
@@ -262,6 +262,7 @@ class Anchor extends React.Component {
       disabled,
       active,
     } = this.props;
+
     const Component = this.getComponentType();
 
     return (

--- a/src/components/Anchor/Anchor.js
+++ b/src/components/Anchor/Anchor.js
@@ -136,7 +136,7 @@ class Anchor extends React.Component {
      * Resolves whether a link is active. Specifying custom rules for whether
      * a link is active may be necessary when using custom onClick logic
      */
-    isActive: PropTypes.func,
+    active: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
   };
 
   static defaultProps = {
@@ -260,7 +260,7 @@ class Anchor extends React.Component {
       onMouseEnter,
       onMouseLeave,
       disabled,
-      isActive,
+      active,
     } = this.props;
     const Component = this.getComponentType();
 
@@ -283,7 +283,10 @@ class Anchor extends React.Component {
             spacing={userSpacing.text(this.props)}
           >
             {this.childrenWithProps({
-              active: isActive(to, match, exact),
+              active:
+                typeof active === 'function'
+                  ? active(to, match, exact)
+                  : !!active,
             })}
           </Component>
         )}


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [*] Visual and behavioral components are separated
- [*] Exported components are documented with examples
- [*] Props have JSDoc comments
- [*] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

Modifies the `Anchor` component to allow overriding the `active` as either a `Boolean` value or a `function` that implements the previous signature. 

This is necessary since some applications may have complex navigation rules where simply checking whether a child exists within a parent does not always work. For example, when using a hash based router child routes may not "match" parent routes (e.g. `/#foo` and `/#bar` may have a parent child relationship as part of the `Navigation` components, but anchor will not show the parent route as active). 

This change allows the implementor to choose how a link is activated (or potentially activate multiple naivgation links)