### PR TITLE
Toggle hover styles

### DIFF
--- a/src/components/DragBox/DragBox.js
+++ b/src/components/DragBox/DragBox.js
@@ -10,7 +10,7 @@ import DragBoxSelect from './DragBoxSelect';
 // avoid missed clicks on buttons when moving the mouse inaccurately.
 // TODO: We should probably turn on drag box once this size is met and not turn it off until
 // the mouse button is released
-const MIN_SIZE_DRAGBOX = 10;
+const MIN_SIZE_DRAGBOX = 16;
 
 const Rect = styled.div`
   border-width: 2px;
@@ -83,6 +83,10 @@ class DragBox extends React.Component {
      * The selector for the element to attach the scroll listener to. Defaults to page body. Do not change after initial call.
      */
     scrollSelector: PropTypes.string,
+    /**
+     * Disables mouse events (such as hover) on children while dragging.
+     */
+    disablePointerEventsWhileDragging: PropTypes.bool,
   };
 
   state = {
@@ -102,6 +106,7 @@ class DragBox extends React.Component {
     onCollisionEnd: noop,
     renderContents: noop,
     scrollSelector: 'body',
+    disablePointerEventsWhileDragging: false,
     renderRect: ({ left, top, width, height }) => (
       <Rect
         style={{
@@ -276,7 +281,9 @@ class DragBox extends React.Component {
 
   shouldDrawRect = rect => {
     const { state: { mouseDown } } = this;
-    return mouseDown && rect.width * rect.height >= MIN_SIZE_DRAGBOX;
+    return (
+      mouseDown && (rect.width + 1) * (rect.height + 1) >= MIN_SIZE_DRAGBOX
+    );
   };
 
   renderRect = rect => {
@@ -333,13 +340,16 @@ class DragBox extends React.Component {
       renderRect,
       renderContents,
       calcRect,
+      props: { disablePointerEventsWhileDragging },
     } = this;
     const rect = calcRect();
     return (
       <DragBoxDiv
         ref={refDragElement}
         onMouseDown={onMouseDown}
-        disablePointerEvents={this.shouldDrawRect(rect)}
+        disablePointerEvents={
+          disablePointerEventsWhileDragging && this.shouldDrawRect(rect)
+        }
       >
         {renderRect(rect)}
         {renderContents()}

--- a/src/components/DragBox/DragBox.md
+++ b/src/components/DragBox/DragBox.md
@@ -31,7 +31,8 @@ purely functional component.
             key={text}
             name={text}
             onClick={toggleItem}
-            selected={collisions.has(text) !== selected.has(text)}
+            selected={collisions.size > 0 ? selected.has(text) || collisions.has(text) : selected.has(text)}
+            hovered={collisions.size > 0 ? selected.has(text) && collisions.has(text) : null}
           >{text}</ToggleButton.Colorful>
         )
       }</Grid>

--- a/src/components/DragBox/DragBoxSelect.js
+++ b/src/components/DragBox/DragBoxSelect.js
@@ -49,27 +49,25 @@ class DragBoxSelect extends React.Component {
     renderRect: PropTypes.func,
   };
 
-  render() {
+  renderDragBox = selectableProps => {
     const { props: { renderContents } } = this;
     return (
-      <Selectable
-        render={selectableProps => (
-          <DragBox
-            {...this.props}
-            onCollisionBegin={items =>
-              items.forEach(selectableProps.toggleItem)
-            }
-            onCollisionEnd={items => items.forEach(selectableProps.toggleItem)}
-            renderContents={dragBoxProps =>
-              renderContents({
-                ...dragBoxProps,
-                ...selectableProps,
-              })
-            }
-          />
-        )}
+      <DragBox
+        {...this.props}
+        onCollisionBegin={items => items.forEach(selectableProps.toggleItem)}
+        onCollisionEnd={items => items.forEach(selectableProps.toggleItem)}
+        renderContents={dragBoxProps =>
+          renderContents({
+            ...dragBoxProps,
+            ...selectableProps,
+          })
+        }
       />
     );
+  };
+
+  render() {
+    return <Selectable render={this.renderDragBox} />;
   }
 }
 

--- a/src/components/ToggleButton/ToggleButton.js
+++ b/src/components/ToggleButton/ToggleButton.js
@@ -31,6 +31,10 @@ class ToggleButton extends React.PureComponent {
      * Whether the button is selected or not
      */
     selected: PropTypes.bool,
+    /**
+     * Whether the button is hovered or not
+     */
+    hovered: PropTypes.bool,
   };
 
   static Small = defaultPropsComponent({
@@ -46,7 +50,12 @@ class ToggleButton extends React.PureComponent {
     onDeselect: noop,
     onSelect: noop,
     selected: false,
+    hovered: null,
     Button: StyledButton,
+  };
+
+  state = {
+    internalHovered: false,
   };
 
   handleClick = ev => {
@@ -54,11 +63,30 @@ class ToggleButton extends React.PureComponent {
     const { props: { onClick, onDeselect, onSelect, selected, name } } = this;
     onClick(name, selected);
     selected ? onDeselect(name) : onSelect(name);
+    this.handleMouseLeave();
   };
 
+  handleMouseEnter = () => this.setState({ internalHovered: true });
+
+  handleMouseLeave = () => this.setState({ internalHovered: false });
+
   render() {
-    const { props: { Button, onClick, ...rest }, handleClick } = this;
-    return <Button onClick={handleClick} {...rest} />;
+    const {
+      props: { Button, onClick, hovered, ...rest },
+      state: { internalHovered },
+      handleClick,
+    } = this;
+    return (
+      <Button
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+        onClick={handleClick}
+        hovered={
+          hovered !== null && hovered != undefined ? hovered : internalHovered
+        }
+        {...rest}
+      />
+    );
   }
 }
 

--- a/src/components/ToggleButton/ToggleButton.js
+++ b/src/components/ToggleButton/ToggleButton.js
@@ -8,6 +8,12 @@ import StyledButton from './styles/StyledToggleButton';
 import ColorfulButton from './styles/ColorfulButton';
 import SmallButton from './styles/SmallButton';
 
+/**
+ * **ToggleButton** is a simple styled button with some extra functionality built-in for handling selection. Control
+ * it by setting `selected`, then use its `onClick` or `onSelect/onDeselect` handlers to implement selection or hook
+ * into the [Selectable](/#!/Selectable) behavior. Set `name` to keep track of which button was pressed when a
+ * click handler fires.
+ */
 class ToggleButton extends React.PureComponent {
   static propTypes = {
     /**
@@ -63,7 +69,6 @@ class ToggleButton extends React.PureComponent {
     const { props: { onClick, onDeselect, onSelect, selected, name } } = this;
     onClick(name, selected);
     selected ? onDeselect(name) : onSelect(name);
-    this.handleMouseLeave();
   };
 
   handleMouseEnter = () => this.setState({ internalHovered: true });
@@ -80,6 +85,7 @@ class ToggleButton extends React.PureComponent {
       <Button
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
+        onMouseUp={this.handleMouseLeave}
         onClick={handleClick}
         hovered={
           hovered !== null && hovered != undefined ? hovered : internalHovered

--- a/src/components/ToggleButton/ToggleButton.md
+++ b/src/components/ToggleButton/ToggleButton.md
@@ -1,10 +1,6 @@
-**ToggleButton** is a simple styled button with some extra functionality built-in for handling selection. Control
-it by setting `selected`, then use its `onClick` or `onSelect/onDeselect` handlers to implement selection or hook
-into the [Selectable](/#!/Selectable) behavior. Set `name` to keep track of which button was pressed when a
-click handler fires.
-
 ```javascript
 <div>
+  <h3>Default</h3>
   <ToggleButton selected={true}>On</ToggleButton>
   <ToggleButton selected={false}>Off</ToggleButton>
   <hr />

--- a/src/components/ToggleButton/styles/ColorfulButton.js
+++ b/src/components/ToggleButton/styles/ColorfulButton.js
@@ -3,16 +3,16 @@ import get from 'extensions/themeGet';
 import StyledButton from './StyledToggleButton';
 
 export default styled(StyledButton)`
-  ${({ selected }) =>
+  ${({ selected, hovered }) =>
     selected
       ? css`
-          background-color: ${get('colors.positive.medium')};
-          border-color: ${get('colors.positive.medium')};
+          background-color: ${hovered
+            ? get('colors.negative.medium')
+            : get('colors.positive.medium')};
+          border-color: ${hovered
+            ? get('colors.negative.medium')
+            : get('colors.positive.medium')};
           color: ${get('colors.text.inverted')};
-          &:hover:not(:disabled) {
-            background-color: ${get('colors.negative.medium')};
-            border-color: ${get('colors.negative.medium')};
-          }
         `
       : ''};
 `;

--- a/src/components/ToggleButton/styles/StyledToggleButton.js
+++ b/src/components/ToggleButton/styles/StyledToggleButton.js
@@ -19,6 +19,7 @@ export default styled.button`
   transition: 0.2s ease;
   font-size: 14px;
   height: 53px;
+  outline: unset;
 
   &:disabled {
     color: ${get('colors.text.disabled')};
@@ -27,7 +28,11 @@ export default styled.button`
     cursor: default;
   }
 
-  ${({ selected }) =>
+  ${({ hovered }) =>
+    hovered &&
+    css`
+      box-shadow: ${get('shadows.focusOutline')};
+    `} ${({ selected }) =>
     selected
       ? css`
           background: ${get('colors.primary.dark')};

--- a/src/components/ToggleButton/styles/StyledToggleButton.js
+++ b/src/components/ToggleButton/styles/StyledToggleButton.js
@@ -28,24 +28,20 @@ export default styled.button`
     cursor: default;
   }
 
-  ${({ hovered }) =>
-    hovered &&
+  &:hover:not(:disabled) {
+    box-shadow: ${get('shadows.focusOutline')};
+  }
+
+  ${({ selected }) =>
+    selected &&
     css`
-      box-shadow: ${get('shadows.focusOutline')};
-    `} ${({ selected }) =>
-    selected
-      ? css`
-          background: ${get('colors.primary.dark')};
-          color: ${get('colors.text.inverted')};
-          border-color: ${get('colors.primary.dark')};
-          &:disabled {
-            background-color: ${get('colors.background.disabledSelected')};
-            border-color: ${get('colors.border.disabled')};
-            color: ${get('colors.text.inverted')};
-          }
-          &:hover:not(:disabled) {
-            box-shadow: ${get('shadows.focusOutline')};
-          }
-        `
-      : ''};
+      background: ${get('colors.primary.dark')};
+      color: ${get('colors.text.inverted')};
+      border-color: ${get('colors.primary.dark')};
+      &:disabled {
+        background-color: ${get('colors.background.disabledSelected')};
+        border-color: ${get('colors.border.disabled')};
+        color: ${get('colors.text.inverted')};
+      }
+    `};
 `;

--- a/stories/DragBox.js
+++ b/stories/DragBox.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import Selectable from 'behaviors/Selectable';
+import DragBox from 'components/DragBox';
+import ToggleButton from 'components/ToggleButton';
+import Grid from 'layouts/Grid';
+
+storiesOf('DragBox', module)
+  .add('standard', () => (
+    <Selectable
+      render={({ toggleItem, selected }) => (
+        <DragBox
+          onMouseUp={collisions => collisions.forEach(toggleItem)}
+          renderContents={({ collisions, getRef }) => (
+            <Grid columns={4}>
+              {Array.from(Array(4).keys())
+                .map(i => `item-${i}`)
+                .map(text => (
+                  <ToggleButton.Colorful
+                    ref={getRef(text)}
+                    key={text}
+                    name={text}
+                    onClick={toggleItem}
+                    selected={
+                      collisions.size > 0
+                        ? selected.has(text) || collisions.has(text)
+                        : selected.has(text)
+                    }
+                    hovered={
+                      collisions.size > 0
+                        ? selected.has(text) && collisions.has(text)
+                        : null
+                    }
+                  >
+                    {text}
+                  </ToggleButton.Colorful>
+                ))}
+            </Grid>
+          )}
+        />
+      )}
+    />
+  ))
+  .add('performance', () => (
+    <Selectable
+      render={({ toggleItem, selected }) => (
+        <DragBox
+          onMouseUp={collisions => collisions.forEach(toggleItem)}
+          renderContents={({ collisions, getRef }) => (
+            <Grid columns={10}>
+              {Array.from(Array(100).keys())
+                .map(i => `item-${i}`)
+                .map(text => (
+                  <ToggleButton.Colorful
+                    ref={getRef(text)}
+                    key={text}
+                    name={text}
+                    onClick={toggleItem}
+                    selected={
+                      collisions.size > 0
+                        ? selected.has(text) || collisions.has(text)
+                        : selected.has(text)
+                    }
+                    hovered={
+                      collisions.size > 0
+                        ? selected.has(text) && collisions.has(text)
+                        : null
+                    }
+                  >
+                    {text}
+                  </ToggleButton.Colorful>
+                ))}
+            </Grid>
+          )}
+        />
+      )}
+    />
+  ));

--- a/stories/index.js
+++ b/stories/index.js
@@ -4,6 +4,7 @@ import './Alert';
 import './Anchor';
 import './Button';
 import './Checkbox';
+import './DragBox';
 import './Fields';
 import './Header';
 import './Input';


### PR DESCRIPTION
![dragfocusfinal](https://user-images.githubusercontent.com/3961037/41938743-e1727170-7961-11e8-9eb3-eb03a7453db6.gif)
**NOTE:** Final version has the regular light blue box shadows
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Drag box is now displayed when width or height is zero if the box is long enough
* After clicking a toggle, it only changes to red once you move your mouse away and back again
* Hover styles are controllable so that drag box can manipulate them
* Use the right box-shadow styles and apply it on hover, regardless of the color state of the toggle button