### PR TITLE
remove withTheme

### DIFF
--- a/docs/design/typography.md
+++ b/docs/design/typography.md
@@ -1,7 +1,7 @@
 
 
 ```js
-const withTheme = require('styled-components').withTheme;
+const irisTheme = require('theme/irisTheme');
 
 const text = [
   'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
@@ -22,18 +22,17 @@ const Font = withTheme(({theme, name}) =>
   )
 );
 
-const FontSizes = withTheme(({theme, name}) =>
+const FontSizes = ({name}) =>
   (
         sizes.map((size) =>
           <Section key={size} title={size}>
             <P style={{
-              fontFamily: theme['bandwidth-shared'].fonts[name],
+              fontFamily: irisTheme.fonts[name],
               fontSize: size,
             }} spacing="lg">{sentence}</P>
           </Section>
         )
   )
-);
 
 const BlueLine = (props) =>
   <div style={{ pointerEvents: 'none', float: 'left', borderBottom: '1px dashed rgba(0, 0, 255, 0.25)', height: '1px', width: '100%', position: 'relative', ...props.style}} />

--- a/src/components/Anchor/Anchor.js
+++ b/src/components/Anchor/Anchor.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withProps } from 'recompose';
+import { defaultProps } from 'recompose';
 import { Route } from 'react-router-dom';
 import userSpacing from 'extensions/userSpacing';
-import { withTheme } from 'styled-components';
 
 import DefaultExternalContentAnchor from './styles/ExternalContentAnchor';
 import DefaultExternalIconAnchor from './styles/ExternalIconAnchor';
@@ -296,34 +295,32 @@ class Anchor extends React.Component {
   }
 }
 
-const ThemedAnchor = withTheme(Anchor);
-
-ThemedAnchor.Danger = ThemedAnchor.Negative = withProps({
+Anchor.Danger = Anchor.Negative = defaultProps({
   ExternalTextAnchor: DefaultExternalTextAnchor.Danger,
   ExternalIconAnchor: DefaultExternalIconAnchor.Danger,
   InternalTextAnchor: DefaultInternalTextAnchor.Danger,
   InternalIconAnchor: DefaultInternalIconAnchor.Danger,
-})(ThemedAnchor);
+})(Anchor);
 
-ThemedAnchor.Positive = withProps({
+Anchor.Positive = defaultProps({
   ExternalTextAnchor: DefaultExternalTextAnchor.Positive,
   ExternalIconAnchor: DefaultExternalIconAnchor.Positive,
   InternalTextAnchor: DefaultInternalTextAnchor.Positive,
   InternalIconAnchor: DefaultInternalIconAnchor.Positive,
-})(ThemedAnchor);
+})(Anchor);
 
-ThemedAnchor.Dark = withProps({
+Anchor.Dark = defaultProps({
   ExternalTextAnchor: DefaultExternalTextAnchor.Dark,
   ExternalIconAnchor: DefaultExternalIconAnchor.Dark,
   InternalTextAnchor: DefaultInternalTextAnchor.Dark,
   InternalIconAnchor: DefaultInternalIconAnchor.Dark,
-})(ThemedAnchor);
+})(Anchor);
 
-ThemedAnchor.Inverted = withProps({
+Anchor.Inverted = defaultProps({
   ExternalTextAnchor: DefaultExternalTextAnchor.Inverted,
   ExternalIconAnchor: DefaultExternalIconAnchor.Inverted,
   InternalTextAnchor: DefaultInternalTextAnchor.Inverted,
   InternalIconAnchor: DefaultInternalIconAnchor.Inverted,
-})(ThemedAnchor);
+})(Anchor);
 
-export default ThemedAnchor;
+export default Anchor;

--- a/src/components/BandwidthProvider/BandwidthProvider.js
+++ b/src/components/BandwidthProvider/BandwidthProvider.js
@@ -21,9 +21,9 @@ class BandwidthProvider extends React.PureComponent {
      */
     customTheme: PropTypes.object,
     /**
-     * Where to attach the drag layer. By default, attaches it to this component
+     * The DOM element to attach the drag layer. By default, attaches it to this component
      */
-    dragLayerPortal: PropTypes.string,
+    dragLayerPortal: PropTypes.object,
     /**
      * Custom StyleRoot component
      */
@@ -36,7 +36,7 @@ class BandwidthProvider extends React.PureComponent {
   };
 
   static defaultProps = {
-    customTheme: null,
+    customTheme: irisTheme,
     dragLayerPortal: null,
     StyleRoot: DefaultStyleRoot,
     DragLayer: DefaultDragLayer,

--- a/src/layouts/Fields/styles/FieldRow.js
+++ b/src/layouts/Fields/styles/FieldRow.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import themeGet from 'extensions/themeGet';
-import { withTheme } from 'styled-components';
 
 const AREA = {
   LABEL: 'label',
@@ -89,4 +88,4 @@ FieldRow.defaultProps = {
   columnCount: 2,
 };
 
-export default withTheme(FieldRow);
+export default FieldRow;


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Removed `withTheme` (should no longer get warnings for it)
* Fixed storybook styles. Default to use `irisTheme` when using `BandwidthProvider` – when used with the bootstrap function, we will double up on our styles, but that's better than including `BandwidthProvider` and not getting styles.