### PR TITLE
Css var legacy support

### DIFF
--- a/src/components/H/H1.js
+++ b/src/components/H/H1.js
@@ -15,7 +15,7 @@ const H1 = styled(tag.h1)
   .attrs({
     spacing: userSpacing.text,
   })`
-  color: var(--colors-primary-default);
+  color: ${get('colors.primary.default')};
   font-weight: 100;
   font-family: ${get('fonts.brand')};
   font-size: 2.5em;

--- a/src/components/Logo/Logo.js
+++ b/src/components/Logo/Logo.js
@@ -1,12 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import themeGet from 'extensions/themeGet';
 import { defaultProps } from 'recompose';
+import irisTheme from 'theme/irisTheme';
 import LogoSvg from './logo.svg';
 import styled from 'styled-components';
 
-const Logo = ({ width, height, color, style, ...rest }) => (
-  <LogoSvg style={{ width, height, fill: color, ...style }} {...rest} />
-);
+// const Logo = ({ width, height, color, style, ...rest }) => (
+//   <LogoSvg style={{ width, height, fill: color, ...style }} {...rest} />
+// );
+//
+const Logo = styled(LogoSvg)`
+  width: ${({ width }) => width};
+  fill: ${({ color }) => (color ? color : themeGet('colors.text.inverted'))};
+  height: ${({ height }) => (height ? height : themeGet('spacing.large'))};
+`;
 
 Logo.propTypes = {
   /**
@@ -36,27 +44,27 @@ Logo.propTypes = {
 Logo.defaultProps = {
   className: null,
   id: null,
-  color: 'var(--colors-text-inverted)',
-  height: 'var(--spacing-large)',
+  color: null,
+  height: null,
 };
 
-Logo.Small = defaultProps({
-  height: 'var(--spacing-medium)',
-})(Logo);
-Logo.Large = defaultProps({
-  height: 'var(--spacing-extra-large)',
-})(Logo);
+Logo.Small = styled(Logo)`
+  height: ${themeGet('spacing.medium')};
+`;
+Logo.Large = styled(Logo)`
+  height: ${themeGet('spacing.extraLarge')};
+`;
 
-Logo.Primary = defaultProps({
-  color: 'var(--colors-primary-default)',
-})(Logo);
-Logo.Primary.Small = defaultProps({
-  color: 'var(--colors-primary-default)',
-  height: 'var(--spacing-medium)',
-})(Logo);
-Logo.Primary.Large = defaultProps({
-  color: 'var(--colors-primary-default)',
-  height: 'var(--spacing-extra-large)',
-})(Logo);
+Logo.Primary = styled(Logo)`
+  fill: ${themeGet('colors.primary.default')};
+`;
+Logo.Primary.Small = styled(Logo)`
+  fill: ${themeGet('colors.primary.default')};
+  height: ${themeGet('spacing.medium')};
+`;
+Logo.Primary.Large = styled(Logo)`
+  fill: ${themeGet('colors.primary.default')};
+  height: ${themeGet('spacing.extraLarge')};
+`;
 
 export default Logo;

--- a/src/components/Navigation/styles/NavigationBar.js
+++ b/src/components/Navigation/styles/NavigationBar.js
@@ -4,14 +4,8 @@ import get from 'extensions/themeGet';
 const NavigationBar = styled.header.withConfig({
   displayName: 'NavigationBar',
 })`
-  /* General text color to use */
-  --nav-color-text: var(--colors-text-inverted);
-  /* Accent color for highlighting links */
-  --nav-color-highlight: var(--colors-primary-dark);
-  --nav-color-background: var(--colors-primary-default);
-
-  background: var(--nav-color-background);
-  color: var(--nav-color-text);
+  background: ${get('colors.primary.default')};
+  color: ${get('colors.text.inverted')};
   border-bottom: ${get('thicknesses.normal')} solid
     ${get('colors.shadow.default')};
   padding: 0 ${get('spacing.large')};
@@ -28,23 +22,21 @@ const NavigationBar = styled.header.withConfig({
 `;
 
 NavigationBar.Sub = styled(NavigationBar)`
-  --nav-color-background: var(--colors-gray-light);
-  --nav-color-text: var(--colors-text-default);
+  background: ${get('colors.gray.light')};
+  color: ${get('colors.text.default')};
 `;
 
 NavigationBar.Dark = styled(NavigationBar)`
-  --nav-color-highlight: var(--colors-primary-default);
-  --nav-color-background: var(--colors-primary-dark);
+  background: ${get('colors.primary.dark')};ß
 `;
 
 NavigationBar.Sub.Dark = styled(NavigationBar)`
-  --nav-color-highlight: var(--colors-primary-default);
-  --nav-color-background: var(--colors-primary-dark);
+  background: ${get('colors.primary.dark')};
 `;
 
 NavigationBar.Light = styled(NavigationBar)`
-  --nav-color-text: var(--colors-text-default);
-  --nav-color-background: var(--colors-background-default);
+  background: ${get('colors.background.default')};
+  color: ${get('colors.text.default')};
 `;
 
 export default NavigationBar;

--- a/src/components/Navigation/styles/NavigationHeading.js
+++ b/src/components/Navigation/styles/NavigationHeading.js
@@ -8,6 +8,5 @@ export default styled.h1`
   height: 30px;
   line-height: 30px;
   display: inline-block;
-  color: var(--nav-color-text);
   white-space: nowrap;
 `;

--- a/src/components/Navigation/styles/NavigationItem.js
+++ b/src/components/Navigation/styles/NavigationItem.js
@@ -22,7 +22,7 @@ const NavigationItem = styled.div.withConfig({ displayName: 'NavigationItem' })`
   &::before {
     content: '';
     opacity: ${({ active }) => (active ? 1 : 0)};
-    background: var(--nav-color-highlight);
+    background: ${get('colors.primary.dark')};
     width: 104%;
     height: ${({ active }) => (active ? '5px' : 0)};
     display: block;
@@ -32,6 +32,10 @@ const NavigationItem = styled.div.withConfig({ displayName: 'NavigationItem' })`
     left: 50%;
     transform: translateX(-50%);
     transition: height 0.2s ease, opacity 0.2s ease;
+  }
+
+  ${NavigationBar.Dark} &, ${NavigationBar.Sub.Dark} & {
+    &:before {background: ${get('colors.primary.default')}; }
   }
 
   ${NavigationItemList}:not(:last-child) & {

--- a/src/components/Navigation/styles/NavigationLogoPairWrapper.js
+++ b/src/components/Navigation/styles/NavigationLogoPairWrapper.js
@@ -9,10 +9,17 @@ export default styled.div`
   color: inherit;
 
   & > ${NavigationHeading} {
-    border-left: ${get('thicknesses.normal')} solid var(--nav-color-text);
+    border-left: ${get('thicknesses.normal')} solid;
+    border-left-color: ${get('colors.text.inverted')};
     margin: auto;
     margin-left: 0.5em;
     padding-left: 0.5em;
+  }
+
+  ${NavigationBar.Light} > &, ${NavigationBar.Sub} > & {
+    & > ${NavigationHeading} {
+      border-left-color: ${get('colors.text.default')};
+    }
   }
 
   ${NavigationBar} > &, ${NavigationBar.Dark} > &, ${NavigationBar.Sub} > & {

--- a/src/components/Select/styles/SelectWrapper.js
+++ b/src/components/Select/styles/SelectWrapper.js
@@ -126,7 +126,7 @@ const SelectWrapper = styled.div`
     color: inherit;
     font-size: inherit;
     line-height: 1.5;
-    padding: calc(var(--spacing-medium) - 1px) var(--spacing-medium);
+    padding: calc(${get('spacing.medium')} - 1px) ${get('spacing.medium')};
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -173,7 +173,7 @@ const SelectWrapper = styled.div`
   .Select-input {
     font-size: inherit;
     line-height: 1.5;
-    padding: calc(var(--spacing-medium) - 1px) var(--spacing-medium);
+    padding: calc(${get('spacing.medium')} - 1px) ${get('spacing.medium')};
     vertical-align: middle;
   }
   .Select-input > input {
@@ -189,7 +189,7 @@ const SelectWrapper = styled.div`
     line-height: 1;
     font-size: inherit;
     min-height: 1em;
-    font: var(--fonts-brand);
+    font: ${get('fonts.brand')};
     /* For IE 8 compatibility */
     -webkit-appearance: none;
   }
@@ -246,16 +246,16 @@ const SelectWrapper = styled.div`
   }
   .Select-arrow {
     display: block;
-    padding: calc(var(--spacing-medium) - 1px) var(--spacing-medium);
+    padding: calc(${get('spacing.medium')} - 1px) ${get('spacing.medium')};
     transition: transform 200ms;
     &::before {
-      font-family: var(--fonts-icon);
+      font-family: ${get('fonts.icon')};
       content: '\\f117';
     }
   }
   .is-open .Select-arrow,
   .Select-arrow-zone:hover > .Select-arrow {
-    border-top-color: #666;
+    border-top-color: ${get('colors.gray.default')};
   }
   .Select--multi .Select-multi-value-wrapper {
     display: flex;
@@ -292,12 +292,13 @@ const SelectWrapper = styled.div`
   }
   .Select-option {
     box-sizing: border-box;
-    border-bottom: var(--thicknesses-normal) solid ${get('colors.gray.border')};
+    border-bottom: ${get('thicknesses.normal')} solid
+      ${get('colors.gray.border')};
     background-color: ${get('colors.background.default')};
     color: ${get('colors.text.default')};
     cursor: pointer;
     display: block;
-    padding: calc(var(--spacing-extra-small) - 1px) var(--spacing-medium);
+    padding: calc(${get('spacing.extraSmall')} - 1px) ${get('spacing.medium')};
   }
   .Select-option.is-geted {
     color: ${get('colors.primary.default')};
@@ -315,7 +316,7 @@ const SelectWrapper = styled.div`
     color: ${get('colors.text.default')};
     cursor: default;
     display: block;
-    padding: calc(var(--spacing-extra-small) - 1px) var(--spacing-medium);
+    padding: calc(${get('spacing.extraSmall')} - 1px) ${get('spacing.medium')};
   }
   .Select--multi .Select-input {
     vertical-align: middle;

--- a/src/extensions/themeGet.js
+++ b/src/extensions/themeGet.js
@@ -1,9 +1,14 @@
 import { cssvarKey } from 'theme/cssvars';
+import irisTheme from 'theme/irisTheme';
+import { get } from 'lodash';
 
 /**
  * @deprecated Provided only to support the legacy theme system.
  * Converts a JSON key (spacing.medium) into a cssvar (var(--spacing-medium)).
  */
-const themeGet = k => props => `var(${cssvarKey(k)})`;
+const themeGet = k => props =>
+  window.CSS && window.CSS.supports('--css-var', 0)
+    ? `var(${cssvarKey(k)})`
+    : get(irisTheme, k);
 
 export default themeGet;

--- a/src/layouts/Fields/styles/FieldRow.js
+++ b/src/layouts/Fields/styles/FieldRow.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import themeGet from 'extensions/themeGet';
+import styled from 'styled-components';
 
 const AREA = {
   LABEL: 'label',
@@ -60,16 +61,23 @@ const calcGridTemplateRows = children =>
     .map(() => 'auto')
     .join(' ');
 
+const FieldRowDiv = styled.div`
+  @supports (display: grid) {
+    display: grid;
+    /* defines spacing between rows and columns */
+    grid-gap: var(--spacing-small) var(--spacing-large);
+  }
+
+  display: flex;
+`;
+
 const FieldRow = ({ children, columns, theme }) => {
   return (
-    <div
+    <FieldRowDiv
       style={{
-        display: 'grid',
         // each row has 3 sub-rows: label, content, helpText.
         // there's a named area for each column.
         gridTemplateAreas: calcGridTemplateAreas(children, columns),
-        // defines spacing between rows and columns
-        gridGap: 'var(--spacing-small) var(--spacing-large)',
         // each column has an equal size. To make fields larger than
         // adjacent fields, use the columnSpan prop on Field to span
         // multiple columns. This keeps all field sizes directly proportional
@@ -80,7 +88,7 @@ const FieldRow = ({ children, columns, theme }) => {
       }}
     >
       {children}
-    </div>
+    </FieldRowDiv>
   );
 };
 


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Changed some usage of css vars back to themeGet
* Added backwards compatibility to themeGet in case css vars aren't available
* Use display: flex for fields when display: flex isn't available. This is a stopgap until we get figure out how to get IE11 support for grid-like fields