### PR TITLE
fixed dragbox breaking when used with pure components

### DIFF
--- a/src/components/DragBox/DragBox.js
+++ b/src/components/DragBox/DragBox.js
@@ -13,6 +13,8 @@ import {
 } from 'lodash';
 
 import DragBoxSelect from './DragBoxSelect';
+import DragBoxRect from './styles/DragBoxRect';
+import DragBoxDiv from './styles/DragBoxDiv';
 
 // Minimum size for the dragbox to become active and prevent click through. This value is based on feel - it helps
 // avoid missed clicks on buttons when moving the mouse inaccurately.
@@ -20,27 +22,25 @@ import DragBoxSelect from './DragBoxSelect';
 // the mouse button is released
 const MIN_SIZE_DRAGBOX = 16;
 
-const Rect = styled.div`
-  border-width: 2px;
-  border-color: black;
-  border-style: dotted;
-  z-index: 100000;
-  position: fixed;
-  pointer-events: none;
-`;
+//Empty class to attach ref to.
+class DragBoxItem extends React.Component {
+  render() {
+    return this.props.children;
+  }
+}
 
-// Div that allows us to disable pointer events on children - this helps to avoid the hoverable behavior on children.
-const DragBoxDiv = styled.div`
-  ${({ disablePointerEvents }) =>
-    disablePointerEvents
-      ? css`
-          & > * {
-            pointer-events: none;
-          }
-        `
-      : null};
-`;
-
+/**
+ * **DragBox** creates an area where the user can drag a box that can then control other types of behavior. It is intended to
+ * be used with the [Selectable](/#!/Selectable) behavior, though it can be used for general purposes. For a prebuilt implementation
+ * of **DragBox** with [Selectable](/#!/Selectable), use [DragBox.Select](#!/DragBoxSelect).
+ *
+ * **DragBox** uses render props, which means that it takes functions that it passes several arguments and uses the result
+ * of that function to perform renders. This allows it to be easily composed with other types of components.
+ *
+ * **DragBox** requires that the `getRef()` function be passed down and called in the `ref` property of each React
+ * component that should be selectable. Note that this requires that the component have an instance - it cannot be a
+ * purely functional component. **DragBox.Item** is provided as a simple wrapper component for this purpose.
+ */
 class DragBox extends React.Component {
   static propTypes = {
     /**
@@ -116,7 +116,7 @@ class DragBox extends React.Component {
     scrollSelector: 'body',
     disablePointerEventsWhileDragging: false,
     renderRect: ({ left, top, width, height }) => (
-      <Rect
+      <DragBoxRect
         style={{
           left,
           top,
@@ -126,6 +126,8 @@ class DragBox extends React.Component {
       />
     ),
   };
+
+  static Item = DragBoxItem;
 
   childElements = {};
 

--- a/src/components/DragBox/DragBox.md
+++ b/src/components/DragBox/DragBox.md
@@ -1,15 +1,10 @@
-**DragBox** creates an area where the user can drag a box that can then control other types of behavior. It is intended to
-be used with the [Selectable](/#!/Selectable) behavior, though it can be used for general purposes. For a out of the box implementation
-of **DragBox** with [Selectable](/#!/Selectable), use [DragBox.Select](#!/DragBoxSelect).
-
-**DragBox** uses a render prop, which means that it takes a function that it passes several arguments and uses the result
-of that function to perform a render. This allows it to be easily composed with other types of components.
-
-**DragBox** also requires that the `getRef` function be passed down and called in the `ref` property of each React
-component that should be selectable. Note that this requires that the component have an instance - it cannot be a
-purely functional component.
-
 ```javascript
+  class Container extends React.Component {
+    render() {
+      return this.props.children;
+    }
+  }
+
   <Selectable
     render={({
       toggleItem,
@@ -26,14 +21,15 @@ purely functional component.
       <Grid columns={4}>{
       ["Apple", "Banana", "Lemon", "Watermelon"]
         .map((text) =>
-          <ToggleButton.Colorful
-            ref={getRef(text)}
-            key={text}
-            name={text}
-            onClick={toggleItem}
-            selected={collisions.size > 0 ? selected.has(text) || collisions.has(text) : selected.has(text)}
-            hovered={collisions.size > 0 ? selected.has(text) && collisions.has(text) : null}
-          >{text}</ToggleButton.Colorful>
+          <DragBox.Item ref={getRef(text)}>
+            <ToggleButton.Colorful
+              key={text}
+              name={text}
+              onClick={toggleItem}
+              selected={collisions.size > 0 ? selected.has(text) || collisions.has(text) : selected.has(text)}
+              hovered={collisions.size > 0 ? selected.has(text) && collisions.has(text) : null}
+            >{text}</ToggleButton.Colorful>
+          </DragBox.Item>
         )
       }</Grid>
     }

--- a/src/components/DragBox/DragBoxSelect.js
+++ b/src/components/DragBox/DragBoxSelect.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+/**
+ *  **DragBoxSelect** is a specialized usage of [DragBox](/#!/DragBox) that is also accessible via `DragBox.Select`. It is
+ *  provided as a convenience as it is a commonly used group of components. All properties available in both
+ *  [Selectable](/#!/Selectable) and [DragBox](/#!/DragBox) are passed into the `renderContents`
+ *  render prop for **DragBoxSelect**.
+ */
 class DragBoxSelect extends React.Component {
   static propTypes = {
     /**

--- a/src/components/DragBox/DragBoxSelect.md
+++ b/src/components/DragBox/DragBoxSelect.md
@@ -1,8 +1,3 @@
-**DragBoxSelect** is a specialized usage of [DragBox](/#!/DragBox) that is also accessible via `DragBox.Select`. It is
-provided as a convenience as it is a commonly used group of components. All properties available in both
-[Selectable](/#!/Selectable) and [DragBox](/#!/DragBox) are passed into the `renderContents`
-render prop for **DragBoxSelect**.
-
 ```javascript
   <DragBox.Select
     renderContents={({
@@ -14,13 +9,14 @@ render prop for **DragBoxSelect**.
     <Grid columns={4}>{
       ["Apple", "Banana", "Lemon", "Watermelon"]
         .map((text) =>
-          <ToggleButton
-            ref={getRef(text)}
-            key={text}
-            name={text}
-            onClick={toggleItem}
-            selected={selected.has(text)}
-          >{text}</ToggleButton>
+          <DragBox.Item ref={getRef(text)}>
+            <ToggleButton
+              key={text}
+              name={text}
+              onClick={toggleItem}
+              selected={selected.has(text)}
+            >{text}</ToggleButton>
+          </DragBox.Item>
         )
     }</Grid>
   }

--- a/src/components/DragBox/styles/DragBoxDiv.js
+++ b/src/components/DragBox/styles/DragBoxDiv.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export default styled.div`
+  ${({ disablePointerEvents }) =>
+    disablePointerEvents
+      ? css`
+          & > * {
+            pointer-events: none;
+          }
+        `
+      : null};
+`;

--- a/src/components/DragBox/styles/DragBoxRect.js
+++ b/src/components/DragBox/styles/DragBoxRect.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export default styled.div`
+  border-width: 2px;
+  border-color: black;
+  border-style: dotted;
+  z-index: 100000;
+  position: fixed;
+  pointer-events: none;
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -137,6 +137,10 @@ export {
 } from './components/DateTimePicker/styles/DateTimeRangePickerContainer';
 export { default as DragBox } from './components/DragBox';
 export { default as DragBoxSelect } from './components/DragBox/DragBoxSelect';
+export { default as DragBoxDiv } from './components/DragBox/styles/DragBoxDiv';
+export {
+  default as DragBoxRect,
+} from './components/DragBox/styles/DragBoxRect';
 export { default as DragContainer } from './components/DragContainer';
 export { default as DragContext } from './components/DragContainer/DragContext';
 export {


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Changes to Existing Components

* Pure components can't have refs, so in order for `DragBox` to work in those cases, you need to wrap components with a simple container. Now we can use `DragBox.Item ref={...}` to handle those cases.