### PR TITLE
radioButton fix styles

### DIFF
--- a/packages/shared-components/src/components/RadioGroup/styles/RadioGroupButtonLabel.js
+++ b/packages/shared-components/src/components/RadioGroup/styles/RadioGroupButtonLabel.js
@@ -6,7 +6,7 @@ const RadioGroupButtonLabel = styled.label`
   border-width: ${get('thicknesses.thick')};
   border-style: solid;
   border-color: ${get('colors.primary.dark')};
-  padding: 1em;
+  padding: 1em 15px;
   cursor: pointer;
   position: relative;
   display: flex;
@@ -67,7 +67,7 @@ const RadioGroupButtonLabel = styled.label`
 
 RadioGroupButtonLabel.Small = styled(RadioGroupButtonLabel)`
   font-size: 0.8em;
-  padding: 5px 10px;
+  padding: 3px 10px;
   font-weight: normal;
   min-width: 30px;
 

--- a/packages/shared-components/src/components/RadioGroup/styles/RadioGroupButtonLabelText.js
+++ b/packages/shared-components/src/components/RadioGroup/styles/RadioGroupButtonLabelText.js
@@ -4,6 +4,7 @@ export default styled.span`
   font-size: inherit;
   font-weight: bold;
   color: inherit;
-  margin: auto auto auto 0;
+  margin: auto 0 auto 0;
   line-height: 21px;
+  text-align: center;
 `;


### PR DESCRIPTION
## Changes to Existing Components
UX requirements:

"there are two sizes. the normal (larger) size should be 53px tall, min-width of 53px, fixed left/right padding of 15px, base font size (14px). the smaller size should be 30px tall, min-width of 30px, fixed left/right padding of 10px, font size 0.8em (11.2px)
all instances should have horizontally and vertically centered text in the button and each button is sized according to its content, not any external container that link implies that the SCL doesn’t match these requirements so we should update it"

![image](https://user-images.githubusercontent.com/17435809/45052392-a8c4a080-b054-11e8-8b64-3c6e35763225.png)

