### PR TITLE
Fix dragbox scroll

### DIFF
--- a/packages/shared-components/src/components/DragBox/DragBox.js
+++ b/packages/shared-components/src/components/DragBox/DragBox.js
@@ -260,7 +260,9 @@ class DragBox extends React.Component {
     } = this;
     const collisionBox = this.calcRect();
     // Divide all clickable refs into two arrays based on whether they are colliding or not.
-    const itemElements = document.querySelectorAll('[data-drag-box-key]');
+    const itemElements = this.dragElement.querySelectorAll(
+      '[data-drag-box-key]',
+    );
     const [collidingNodes, notCollidingNodes] = partition(
       itemElements,
       node => {
@@ -406,7 +408,7 @@ class DragBox extends React.Component {
     const rect = calcRect();
     return (
       <DragBoxDiv
-        ref={refDragElement}
+        innerRef={refDragElement}
         onMouseDown={onMouseDown}
         disablePointerEvents={
           disablePointerEventsWhileDragging && this.shouldDrawRect(rect)

--- a/packages/shared-components/stories/DragBox.js
+++ b/packages/shared-components/stories/DragBox.js
@@ -18,7 +18,7 @@ storiesOf('DragBox', module)
                 .map(i => `item-${i}`)
                 .map(text => (
                   <ToggleButton.Colorful
-                    ref={getRef(text)}
+                    innerRef={getRef(text)}
                     key={text}
                     name={text}
                     onClick={toggleItem}
@@ -46,14 +46,16 @@ storiesOf('DragBox', module)
     <Selectable
       render={({ toggleItem, selected }) => (
         <DragBox
-          onMouseUp={collisions => collisions.forEach(toggleItem)}
+          onMouseUp={collisions => {
+            collisions.forEach(toggleItem);
+          }}
           renderContents={({ collisions, getRef }) => (
             <Grid columns={10}>
               {Array.from(Array(100).keys())
                 .map(i => `item-${i}`)
                 .map(text => (
                   <ToggleButton.Colorful
-                    ref={getRef(text)}
+                    innerRef={getRef(text)}
                     key={text}
                     name={text}
                     onClick={toggleItem}
@@ -76,4 +78,42 @@ storiesOf('DragBox', module)
         />
       )}
     />
+  ))
+  .add('scroll area', () => (
+    <div id="scrollContext" style={{ overflowY: 'scroll', height: '100px' }}>
+      <Selectable
+        render={({ toggleItem, selected }) => (
+          <DragBox
+            scrollSelector="#scrollContext"
+            onMouseUp={collisions => collisions.forEach(toggleItem)}
+            renderContents={({ collisions, getRef }) => (
+              <Grid columns={10}>
+                {Array.from(Array(100).keys())
+                  .map(i => `item-${i}`)
+                  .map(text => (
+                    <ToggleButton.Colorful
+                      innerRef={getRef(text)}
+                      key={text}
+                      name={text}
+                      onClick={toggleItem}
+                      selected={
+                        collisions.size > 0
+                          ? selected.has(text) || collisions.has(text)
+                          : selected.has(text)
+                      }
+                      hovered={
+                        collisions.size > 0
+                          ? selected.has(text) && collisions.has(text)
+                          : null
+                      }
+                    >
+                      {text}
+                    </ToggleButton.Colorful>
+                  ))}
+              </Grid>
+            )}
+          />
+        )}
+      />
+    </div>
   ));

--- a/packages/shared-components/stories/DragBox.js
+++ b/packages/shared-components/stories/DragBox.js
@@ -12,13 +12,14 @@ storiesOf('DragBox', module)
       render={({ toggleItem, selected }) => (
         <DragBox
           onMouseUp={collisions => collisions.forEach(toggleItem)}
-          renderContents={({ collisions, getRef }) => (
+          renderContents={({ collisions, ref }) => (
             <Grid columns={4}>
               {Array.from(Array(4).keys())
                 .map(i => `item-${i}`)
                 .map(text => (
                   <ToggleButton.Colorful
-                    innerRef={getRef(text)}
+                    innerRef={ref}
+                    data-drag-box-key={text}
                     key={text}
                     name={text}
                     onClick={toggleItem}
@@ -49,13 +50,14 @@ storiesOf('DragBox', module)
           onMouseUp={collisions => {
             collisions.forEach(toggleItem);
           }}
-          renderContents={({ collisions, getRef }) => (
+          renderContents={({ collisions, ref }) => (
             <Grid columns={10}>
               {Array.from(Array(100).keys())
                 .map(i => `item-${i}`)
                 .map(text => (
                   <ToggleButton.Colorful
-                    innerRef={getRef(text)}
+                    innerRef={ref}
+                    data-drag-box-key={text}
                     key={text}
                     name={text}
                     onClick={toggleItem}
@@ -86,13 +88,14 @@ storiesOf('DragBox', module)
           <DragBox
             scrollSelector="#scrollContext"
             onMouseUp={collisions => collisions.forEach(toggleItem)}
-            renderContents={({ collisions, getRef }) => (
+            renderContents={({ collisions, ref }) => (
               <Grid columns={10}>
                 {Array.from(Array(100).keys())
                   .map(i => `item-${i}`)
                   .map(text => (
                     <ToggleButton.Colorful
-                      innerRef={getRef(text)}
+                      innerRef={ref}
+                      data-drag-box-key={text}
                       key={text}
                       name={text}
                       onClick={toggleItem}
@@ -116,4 +119,40 @@ storiesOf('DragBox', module)
         )}
       />
     </div>
+  ))
+  .add('non-data-attr based', () => (
+    <Selectable
+      render={({ toggleItem, selected }) => (
+        <DragBox
+          onMouseUp={collisions => collisions.forEach(toggleItem)}
+          renderContents={({ collisions, getRef }) => (
+            <Grid columns={4}>
+              {Array.from(Array(4).keys())
+                .map(i => `item-${i}`)
+                .map(text => (
+                  <ToggleButton.Colorful
+                    innerRef={getRef(text)}
+                    data-drag-box-key={text}
+                    key={text}
+                    name={text}
+                    onClick={toggleItem}
+                    selected={
+                      collisions.size > 0
+                        ? selected.has(text) || collisions.has(text)
+                        : selected.has(text)
+                    }
+                    hovered={
+                      collisions.size > 0
+                        ? selected.has(text) && collisions.has(text)
+                        : null
+                    }
+                  >
+                    {text}
+                  </ToggleButton.Colorful>
+                ))}
+            </Grid>
+          )}
+        />
+      )}
+    />
   ));

--- a/packages/shared-components/stories/index.js
+++ b/packages/shared-components/stories/index.js
@@ -10,7 +10,6 @@ import './DragBox';
 import './Fields';
 import './Header';
 import './Input';
-import './Navigation';
 import './Paragraph';
 import './Radio';
 import './Select';


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props

## Breaking Changes

* Should be no breaking changes

## Changes to Existing Components

* Fixed the scrolling interaction with DragBox. Now responds to window or container scroll appropriately
* Added a new `ref` mode for attaching refs to items, where you supply a `data-drag-box-key` prop to the item instead of calling a `getRef(key)` function.
* Simplified DragBox internally to use `data-drag-box-key` for tracking item elements rather than storing refs to elements.