### PR TITLE
UI-236 fix seachBox for firefox

### DIFF
--- a/packages/shared-components/src/components/SearchBox/styles/SearchBoxSearchButton.js
+++ b/packages/shared-components/src/components/SearchBox/styles/SearchBoxSearchButton.js
@@ -8,18 +8,21 @@ const INACTIVE_SIZE = '2em';
 export default styled.button`
   position: relative;
   display: block;
-  width: 0;
+  width: ${ACTIVE_SIZE};
+  height: ${ACTIVE_SIZE};
+  line-height: ${ACTIVE_SIZE};
   overflow: visible;
   background: none;
   border: none;
   padding: 0;
   font-size: 1.5em;
   outline: none;
+  margin-left: -${ACTIVE_SIZE} !important;
 
   &::before {
     position: absolute;
     top: -0.125em;
-    left: calc(-${ACTIVE_SIZE} / 2);
+    left: 15px;
     font-family: Bandwidth;
     content: "${icons('search')}";
     width: ${ACTIVE_SIZE};
@@ -39,13 +42,18 @@ export default styled.button`
     box-shadow: ${get('shadows.short')};
   }
 
+  &:disabled {
+    margin-left: -${ACTIVE_SIZE};
+  }
+
   &:disabled::before {
+    position: absolute;
     width: ${INACTIVE_SIZE};
     height: ${INACTIVE_SIZE};
     top: 0.25em;
     line-height: ${INACTIVE_SIZE};
     font-size: 1em;
-    left: calc(-${INACTIVE_SIZE} - ${get('spacing.small')});
+    left: 10px;
     background: ${get('colors.background.default')};
     color: ${get('colors.text.disabled')};
     cursor: default;


### PR DESCRIPTION
## Changes to Existing Components

SearchBox search button does not work on Firefox due to the fact that button (hidden) width is 0. I had to set a width to it and then adjust its position to the :before element.

![image](https://user-images.githubusercontent.com/17435809/45299887-eacd6680-b4da-11e8-8d5f-cc7a9ae8f201.png)
