### PR TITLE
Use placeholder text color when select has no value

### DIFF
--- a/packages/shared-components/src/components/Select/Select.js
+++ b/packages/shared-components/src/components/Select/Select.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import LibSelect from 'react-select';
-import arrowImage from './arrow.png';
-import theme from '../../theme';
 import _ from 'lodash';
 import selectOptionPrimaryValue from '../../extensions/selectItemPrimaryValue';
 import Loader from '../Loader';
@@ -171,7 +169,7 @@ class Select extends React.PureComponent {
     required: false,
     allowNone: false,
     invalid: false,
-    placeholder: 'None',
+    placeholder: 'Select one',
     renderOption: selectOptionPrimaryValue,
     getOptionValue: selectOptionPrimaryValue,
     searchable: false,
@@ -224,13 +222,14 @@ class Select extends React.PureComponent {
       isLoading,
       loading,
       invalid,
+      value,
       Wrapper,
     } = this.props;
     const combinedLoading = loading || isLoading;
-    const combinedPlaceholder = (noneText !== undefined) ? noneText : placeholder;
+    const combinedPlaceholder = noneText !== undefined ? noneText : placeholder;
 
     return (
-      <Wrapper invalid={invalid}>
+      <Wrapper invalid={invalid} value={value}>
         <LibSelect
           {...this.props}
           options={this.convertOptions()}

--- a/packages/shared-components/src/components/Select/styles/SelectWrapper.js
+++ b/packages/shared-components/src/components/Select/styles/SelectWrapper.js
@@ -1,6 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
 import get from 'extensions/themeGet';
-import arrowImage from '../arrow.png';
 
 const fadeIn = keyframes`
   from {
@@ -8,12 +7,6 @@ const fadeIn = keyframes`
   }
   to {
     opacity: 1;
-  }
-`;
-
-const spin = keyframes`
-  to {
-    transform: rotate(1turn);
   }
 `;
 
@@ -123,7 +116,7 @@ const SelectWrapper = styled.div`
 
   .Select-placeholder,
   .Select--single > .Select-control .Select-value {
-    color: inherit;
+    color: ${({ value }) => (value ? 'inherit' : get('colors.text.disabled'))};
     font-size: inherit;
     line-height: 1.5;
     padding: calc(${get('spacing.medium')} - 1px) ${get('spacing.medium')};


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props
- [x] Any extra props are spread into the outermost rendered element

## Changes to Existing Components

* Select now has a light shade of gray when there's no value set.
