### PR TITLE
reset text styles on callout, introduce fontsize css var

### DIFF
--- a/packages/shared-components/src/bootstrap.js
+++ b/packages/shared-components/src/bootstrap.js
@@ -29,7 +29,7 @@ const bootstrapFromTheme = theme => {
       width: 100%;
       height: 100%;
       font-family: var(--fonts-brand);
-      font-size: 14px;
+      font-size: var(--font-sizes-default);
       letter-spacing: 0.28px;
       margin: 0;
       line-height: 1.5;

--- a/packages/shared-components/src/components/BandwidthProvider/styles/StyleRoot.js
+++ b/packages/shared-components/src/components/BandwidthProvider/styles/StyleRoot.js
@@ -6,7 +6,7 @@ export default styled.div`
   font-family: ${get('fonts.default')};
   background: ${get('colors.background.default')};
   color: ${get('colors.text.default')};
-  font-size: 14px;
+  font-size: ${get('fontSizes.default')};
   line-height: 1.5;
   letter-spacing: 0.28px;
 

--- a/packages/shared-components/src/components/Callout/styles/CalloutContainer.js
+++ b/packages/shared-components/src/components/Callout/styles/CalloutContainer.js
@@ -1,13 +1,20 @@
 import styled from 'styled-components';
+import themeGet from 'extensions/themeGet';
 
 const HelpCalloutContainer = styled.div`
-  background-color: var(--colors-background-default);
-  border: 1px solid var(--colors-border-medium);
+  /* reset text styles */
+
+  color: ${themeGet('colors.text.default')};
+  font-style: normal;
+  font-size: ${themeGet('fontSizes.default')};
+
+  background-color: ${themeGet('colors.background.default')};
+  border: 1px solid ${themeGet('colors.border.medium')};
   border-radius: 4px;
   overflow-y: auto;
-  box-shadow: var(--shadows-short);
+  box-shadow: ${themeGet('shadows.short')};
   z-index: 100000;
-  padding: var(--spacing-medium);
+  padding: ${themeGet('spacing.medium')};
   pointer-events: none;
   max-width: ${({ maxWidth }) =>
     typeof maxWidth === 'number' ? maxWidth + 'px' : maxWidth};

--- a/packages/shared-components/src/theme/irisTheme.js
+++ b/packages/shared-components/src/theme/irisTheme.js
@@ -110,6 +110,10 @@ export const thicknesses = {
   extraLarge: '3px',
 };
 
+export const fontSizes = {
+  default: '14px',
+};
+
 export default {
   name: 'iris',
   colors,
@@ -117,4 +121,5 @@ export default {
   shadows,
   spacing,
   thicknesses,
+  fontSizes,
 };


### PR DESCRIPTION
- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props
- [x] Any extra props are spread into the outermost rendered element
