### PR TITLE
components that need to generate their own ids will maintain them acr…

### DIFF
--- a/packages/shared-components/src/components/Checkbox/Checkbox.js
+++ b/packages/shared-components/src/components/Checkbox/Checkbox.js
@@ -11,46 +11,46 @@ export default class Checkbox extends React.PureComponent {
     /**
      * Adds a class name to the input element.
      */
-    className: PropTypes.string
+    className: PropTypes.string,
     /**
      * Adds an id to the input element.
-     */,
-    id: PropTypes.string
+     */
+    id: PropTypes.string,
     /**
      * The value of the checkbox.
-     */,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
+     */
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     /**
      * Whether the checkbox is checked or not.
-     */,
-    checked: PropTypes.bool
+     */
+    checked: PropTypes.bool,
     /**
      * Whether the checkbox is required for form submission.
-     */,
-    required: PropTypes.bool
+     */
+    required: PropTypes.bool,
     /**
      * Whether the user is prevented from interacting with the checkbox.
-     */,
-    disabled: PropTypes.bool
+     */
+    disabled: PropTypes.bool,
     /**
      * A description to display next to the checkbox.
-     */,
-    description: PropTypes.node
+     */
+    description: PropTypes.node,
     /**
      * Callback for the onChange event of the input.
-     */,
-    onChange: PropTypes.func
+     */
+    onChange: PropTypes.func,
     /**
      * A component to render an input, by default hidden.
-     */,
-    Input: PropTypes.func
+     */
+    Input: PropTypes.func,
     /**
      * A component to render a label. By default this component renders the checkbox itself as a pseudoelement pair.
-     */,
-    Label: PropTypes.func
+     */
+    Label: PropTypes.func,
     /**
      * A component to render the wrapping element of the assembled checkbox/label
-     */,
+     */
     Container: PropTypes.func,
   };
 

--- a/packages/shared-components/src/components/Checkbox/Checkbox.js
+++ b/packages/shared-components/src/components/Checkbox/Checkbox.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import generateId from '../../extensions/generateId';
+import generateId from 'extensions/generateId';
 import CheckboxInput from './styles/CheckboxInput';
 import CheckboxLabel from './styles/CheckboxLabel';
 import CheckboxContainer from './styles/CheckboxContainer';
@@ -11,46 +11,46 @@ export default class Checkbox extends React.PureComponent {
     /**
      * Adds a class name to the input element.
      */
-    className: PropTypes.string,
+    className: PropTypes.string
     /**
      * Adds an id to the input element.
-     */
-    id: PropTypes.string,
+     */,
+    id: PropTypes.string
     /**
      * The value of the checkbox.
-     */
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+     */,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
     /**
      * Whether the checkbox is checked or not.
-     */
-    checked: PropTypes.bool,
+     */,
+    checked: PropTypes.bool
     /**
      * Whether the checkbox is required for form submission.
-     */
-    required: PropTypes.bool,
+     */,
+    required: PropTypes.bool
     /**
      * Whether the user is prevented from interacting with the checkbox.
-     */
-    disabled: PropTypes.bool,
+     */,
+    disabled: PropTypes.bool
     /**
      * A description to display next to the checkbox.
-     */
-    description: PropTypes.node,
+     */,
+    description: PropTypes.node
     /**
      * Callback for the onChange event of the input.
-     */
-    onChange: PropTypes.func,
+     */,
+    onChange: PropTypes.func
     /**
      * A component to render an input, by default hidden.
-     */
-    Input: PropTypes.func,
+     */,
+    Input: PropTypes.func
     /**
      * A component to render a label. By default this component renders the checkbox itself as a pseudoelement pair.
-     */
-    Label: PropTypes.func,
+     */,
+    Label: PropTypes.func
     /**
      * A component to render the wrapping element of the assembled checkbox/label
-     */
+     */,
     Container: PropTypes.func,
   };
 
@@ -71,6 +71,8 @@ export default class Checkbox extends React.PureComponent {
   static Small = defaultProps({
     Label: CheckboxLabel.Small,
   })(Checkbox);
+
+  defaultId = generateId('checkbox');
 
   computeChecked = () => {
     const { value, checked } = this.props;
@@ -99,9 +101,9 @@ export default class Checkbox extends React.PureComponent {
 
   render() {
     const {
+      id,
       className,
       disabled,
-      value,
       name,
       required,
       description,
@@ -109,17 +111,16 @@ export default class Checkbox extends React.PureComponent {
       Container,
       Input,
       Label,
-      checked,
     } = this.props;
 
-    const id = this.props.id || generateId('checkbox');
+    const finalId = id || this.defaultId;
     const isChecked = this.computeChecked();
 
     return (
       <Container>
         <Input
           name={name}
-          id={id}
+          id={finalId}
           className={className}
           type="checkbox"
           disabled={disabled}
@@ -128,7 +129,7 @@ export default class Checkbox extends React.PureComponent {
           required={required}
           onChange={onChange}
         />
-        <Label htmlFor={id} active={isChecked}>
+        <Label htmlFor={finalId} active={isChecked}>
           {description}
         </Label>
       </Container>

--- a/packages/shared-components/src/components/Radio/Radio.js
+++ b/packages/shared-components/src/components/Radio/Radio.js
@@ -70,6 +70,8 @@ class Radio extends React.PureComponent {
     Label: RadioLabel,
   };
 
+  defaultId = generateId('radio');
+
   render() {
     const {
       id,
@@ -82,7 +84,9 @@ class Radio extends React.PureComponent {
       Label,
       ...rest
     } = this.props;
-    const finalId = id || generateId('toggle');
+
+    const finalId = id || this.defaultId;
+
     return (
       <Container>
         <Input

--- a/packages/shared-components/src/components/RadioGroup/RadioGroup.js
+++ b/packages/shared-components/src/components/RadioGroup/RadioGroup.js
@@ -63,8 +63,10 @@ class RadioGroup extends React.Component {
     name: undefined,
   };
 
+  defaultId = generateId('radioGroup');
+
   getOptions = () => this.props.options || this.props.choices;
-  getName = () => this.props.name || generateId('radioGroup');
+  getName = () => this.props.name || this.defaultId;
 
   optionsToButtons = () => {
     const { value, onChange, disabled, required, Button } = this.props;

--- a/packages/shared-components/src/components/Toggle/Toggle.js
+++ b/packages/shared-components/src/components/Toggle/Toggle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import generateId from '../../extensions/generateId';
+import generateId from 'extensions/generateId';
 import ToggleContainer from './styles/ToggleContainer';
 import ToggleInput from './styles/ToggleInput';
 import ToggleLabel from './styles/ToggleLabel';

--- a/packages/shared-components/stories/Checkbox.js
+++ b/packages/shared-components/stories/Checkbox.js
@@ -2,16 +2,40 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import Checkbox from 'components/Checkbox';
-import Horizontal from 'layouts/Horizontal';
 
-storiesOf('Checkbox', module).add('types', () => (
-  <React.Fragment>
-    <h2>Standard</h2>
-    <Checkbox onChange={action('checkbox')} description="Foo" />
-    <h2>Disabled</h2>
-    <Horizontal>
+class RenderEverySecond extends React.Component {
+  state = { ct: 0 };
+
+  componentDidMount = () => {
+    this.__interval = setInterval(
+      () => this.setState(state => ({ ct: state.ct + 1 })),
+      1000,
+    );
+  };
+
+  render() {
+    return (
+      <div>
+        {React.cloneElement(this.props.children, {
+          description: 'Count: ' + this.state.ct,
+        })}
+      </div>
+    );
+  }
+}
+
+storiesOf('Checkbox', module)
+  .add('types', () => (
+    <React.Fragment>
+      <h2>Standard</h2>
+      <Checkbox onChange={action('checkbox')} description="Foo" />
+      <h2>Disabled</h2>
       <Checkbox disabled description="Disabled" />
       <Checkbox disabled checked description="Disabled checked" />
-    </Horizontal>
-  </React.Fragment>
-));
+    </React.Fragment>
+  ))
+  .add('rerender keeps id', () => (
+    <RenderEverySecond>
+      <Checkbox onChange={action('checkbox')} description="Foo" />
+    </RenderEverySecond>
+  ));

--- a/packages/shared-components/stories/Radio.js
+++ b/packages/shared-components/stories/Radio.js
@@ -2,23 +2,49 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import Radio from 'components/Radio';
-import Grid from 'layouts/Grid';
 
-storiesOf('Radio', module).add('types', () => (
-  <Grid columns={1} maxSize="600px">
-    <h2>Standard</h2>
-    <Radio onChange={action('onChange')} description="Unselected" />
-    <Radio onChange={action('onChange')} checked description="Selected" />
-    <Radio
-      onChange={action('onChange')}
-      disabled
-      description="Disabled & unselected"
-    />
-    <Radio
-      onChange={action('onChange')}
-      disabled
-      checked
-      description="Disabled & selected"
-    />
-  </Grid>
-));
+class RenderEverySecond extends React.Component {
+  state = { ct: 0 };
+
+  componentDidMount = () => {
+    this.__interval = setInterval(
+      () => this.setState(state => ({ ct: state.ct + 1 })),
+      1000,
+    );
+  };
+
+  render() {
+    return (
+      <div>
+        {React.cloneElement(this.props.children, {
+          description: 'Count: ' + this.state.ct,
+        })}
+      </div>
+    );
+  }
+}
+
+storiesOf('Radio', module)
+  .add('types', () => (
+    <React.Fragment>
+      <h2>Standard</h2>
+      <Radio onChange={action('onChange')} description="Unselected" />
+      <Radio onChange={action('onChange')} checked description="Selected" />
+      <Radio
+        onChange={action('onChange')}
+        disabled
+        description="Disabled & unselected"
+      />
+      <Radio
+        onChange={action('onChange')}
+        disabled
+        checked
+        description="Disabled & selected"
+      />
+    </React.Fragment>
+  ))
+  .add('rerender keeps id', () => (
+    <RenderEverySecond>
+      <Radio onChange={action('onChange')} description="Foo" />
+    </RenderEverySecond>
+  ));

--- a/packages/shared-components/stories/Toggle.js
+++ b/packages/shared-components/stories/Toggle.js
@@ -4,18 +4,54 @@ import { action } from '@storybook/addon-actions';
 import Toggle from 'components/Toggle';
 import Grid from 'layouts/Grid';
 
-storiesOf('Toggle', module).add('standard', () => (
-  <Grid columns={1}>
-    <h2>Standard</h2>
-    <Toggle onChange={action('onChange')} description="Off" />
-    <Toggle onChange={action('onChange')} description="On" value={true} />
-    <h2>Disabled</h2>
-    <Toggle onChange={action('onChange')} disabled description="Disabled Off" />
-    <Toggle
-      onChange={action('onChange')}
-      disabled
-      description="Disabled On"
-      value={true}
-    />
-  </Grid>
-));
+class RenderEverySecond extends React.Component {
+  state = { ct: 0 };
+
+  componentDidMount = () => {
+    this.__interval = setInterval(
+      () => this.setState(state => ({ ct: state.ct + 1 })),
+      1000,
+    );
+  };
+
+  render() {
+    return (
+      <div>
+        {React.cloneElement(this.props.children, {
+          description: 'Count: ' + this.state.ct,
+        })}
+      </div>
+    );
+  }
+}
+
+storiesOf('Toggle', module)
+  .add('standard', () => (
+    <Grid columns={1}>
+      <h2>Standard</h2>
+      <Toggle onChange={action('onChange')} description="Off" />
+      <Toggle onChange={action('onChange')} description="On" value={true} />
+      <h2>Disabled</h2>
+      <Toggle
+        onChange={action('onChange')}
+        disabled
+        description="Disabled Off"
+      />
+      <Toggle
+        onChange={action('onChange')}
+        disabled
+        description="Disabled On"
+        value={true}
+      />
+    </Grid>
+  ))
+  .add('rerender keeps id', () => (
+    <React.Fragment>
+      <RenderEverySecond>
+        <Toggle onChange={action('onChange')} description="Off" />
+      </RenderEverySecond>
+      <RenderEverySecond>
+        <Toggle onChange={action('onChange')} description="Off" />
+      </RenderEverySecond>
+    </React.Fragment>
+  ));


### PR DESCRIPTION
…oss renders

## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props
- [x] Any extra props are spread into the outermost rendered element

## Changes to Existing Components

* Certain components need to have ids that match up between two DOM elements (using the html `for` attribute). These ids were being generated in the render function, which meant that they produced new DOM elements if they were rendered. Now, they will maintain the same id.