### PR TITLE
fix field label spacing with help callout

### DIFF
--- a/packages/shared-components/src/layouts/Fields/Field.js
+++ b/packages/shared-components/src/layouts/Fields/Field.js
@@ -143,7 +143,11 @@ class Field extends React.Component {
     };
 
     const HelpCallout = helpCallout && (
-      <Callout content={helpCallout} {...helpCalloutProps}>
+      <Callout
+        style={{ position: 'relative', top: '-15px' }}
+        content={helpCallout}
+        {...helpCalloutProps}
+      >
         <HelpIcon name="help" />
       </Callout>
     );

--- a/packages/shared-components/src/layouts/Fields/styles/HelpIcon.js
+++ b/packages/shared-components/src/layouts/Fields/styles/HelpIcon.js
@@ -6,4 +6,5 @@ export default styled(Icon)`
   margin: auto;
   margin-left: var(--spacing-extra-small);
   font-weight: normal;
+  position: absolute;
 `;

--- a/packages/shared-components/src/layouts/Fields/styles/LabelContainer.js
+++ b/packages/shared-components/src/layouts/Fields/styles/LabelContainer.js
@@ -7,4 +7,3 @@ const LabelContainer = styled.div`
 `;
 
 export default LabelContainer;
-

--- a/packages/shared-components/stories/Fields.js
+++ b/packages/shared-components/stories/Fields.js
@@ -15,7 +15,12 @@ storiesOf('Fields', module).add('standard', () => (
     <Field label="label" helpText="help">
       <Input placeholder="Content" />
     </Field>
-    <Field required label="Required:" helpText="A required field">
+    <Field
+      required
+      label="Required:"
+      helpText="A required field"
+      helpCallout="Even more help"
+    >
       <Input placeholder="Content" />
     </Field>
     <Field disabled label="Disabled" helpText="A disabled field">


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props
- [x] Any extra props are spread into the outermost rendered element

## Changes to Existing Components

* Field labels previously were taking up 21px when they had a help callout instead of the normal 11px. Now they will take up the right amount of space, since the help callout icon will not take up any space at all.