### PR TITLE
UI-206 change secondary button border width

### DIFF
--- a/packages/shared-components/src/components/Button/Button.js
+++ b/packages/shared-components/src/components/Button/Button.js
@@ -132,6 +132,7 @@ Button.Secondary = styled(Button)`
   color: ${get('colors.primary.dark')};
   border-color: ${get('colors.primary.dark')};
   background: transparent;
+  border-width: ${get('thicknesses.wide')};
 
   &:hover:not(:disabled),
   &:focus:not(:disabled) {


### PR DESCRIPTION

## Changes to Existing Components

change secondary button border width per UX request:



![image](https://user-images.githubusercontent.com/17435809/47452214-ae5a7f00-d797-11e8-88c1-39d6d57b81ff.png)

