### PR TITLE
Fix docs links on dev.bandwidth.com

### DIFF
--- a/docs/color.md
+++ b/docs/color.md
@@ -1,4 +1,4 @@
-Our colors are available as part of themes. Use [BandwidthProvider](/#!/BandwidthProvider) to provide themes in your app,
+Our colors are available as part of themes. Use [BandwidthProvider](#!/BandwidthProvider) to provide themes in your app,
 then use CSS variables to reference the colors (e.g.,  `var(--colors-primary-light)`).
 
 ```javascript noeditor

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -192,7 +192,7 @@ Clicking a toolbar anchor should disable any other sibling anchors. This should 
 
 ## Data Presentation
 
-When displaying input fields, you should aim to present information in a way that users can identify what is currently editable, what was editable, and what was system generated. Use the [Field](#!/Field) and [Input](/#!/Input) components to create forms with input fields.
+When displaying input fields, you should aim to present information in a way that users can identify what is currently editable, what was editable, and what was system generated. Use the [Field](#!/Field) and [Input](#!/Input) components to create forms with input fields.
 
 ```jsx
 <form>

--- a/src/components/DragBox/DragBox.js
+++ b/src/components/DragBox/DragBox.js
@@ -16,8 +16,8 @@ const MIN_SIZE_DRAGBOX = 16;
 
 /**
  * **DragBox** creates an area where the user can drag a box that can then control other types of behavior. It is intended to
- * be used with the [Selectable](/#!/Selectable) behavior, though it can be used for general purposes. For a prebuilt implementation
- * of **DragBox** with [Selectable](/#!/Selectable), use [DragBox.Select](#!/DragBoxSelect).
+ * be used with the [Selectable](#!/Selectable) behavior, though it can be used for general purposes. For a prebuilt implementation
+ * of **DragBox** with [Selectable](#!/Selectable), use [DragBox.Select](#!/DragBoxSelect).
  *
  * **DragBox** uses render props, which means that it takes functions that it passes several arguments and uses the result
  * of that function to perform renders. This allows it to be easily composed with other types of components.

--- a/src/components/DragBox/DragBoxSelect.js
+++ b/src/components/DragBox/DragBoxSelect.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
- *  **DragBoxSelect** is a specialized usage of [DragBox](/#!/DragBox) that is also accessible via `DragBox.Select`. It is
+ *  **DragBoxSelect** is a specialized usage of [DragBox](#!/DragBox) that is also accessible via `DragBox.Select`. It is
  *  provided as a convenience as it is a commonly used group of components. All properties available in both
- *  [Selectable](/#!/Selectable) and [DragBox](/#!/DragBox) are passed into the `renderContents`
+ *  [Selectable](#!/Selectable) and [DragBox](#!/DragBox) are passed into the `renderContents`
  *  render prop for **DragBoxSelect**.
  * @visibleName DragBox.Select
  */

--- a/src/components/DragContainer/DragContainer.js
+++ b/src/components/DragContainer/DragContainer.js
@@ -19,8 +19,8 @@ const DefaultControls = (
 );
 
 /**
- * This is a prebuilt example container that can be used with [DragList](/#!/DragList)
- * or [DragGroup](/#!/DragGroup). It features a drag handle and a section that can have
+ * This is a prebuilt example container that can be used with [DragList](#!/DragList)
+ * or [DragGroup](#!/DragGroup). It features a drag handle and a section that can have
  * controls for the item - just set `controls` to a react node and attach handlers for
  * the click events as needed.
  */

--- a/src/components/DragGroup/DragGroup.js
+++ b/src/components/DragGroup/DragGroup.js
@@ -12,7 +12,7 @@ import DragContainer from 'components/DragContainer';
  * on `itemType`. The ordering of items within a group is arbitrary and non-editable.
  * Dragging is not enabled until more than one group is present.
  *
- * > **Note:** You must include [BandwidthProvider](/#!/BandwidthProvider)
+ * > **Note:** You must include [BandwidthProvider](#!/BandwidthProvider)
  * at or near the root of your application to use drag and drop functionality.
  */
 class DragGroup extends React.Component {

--- a/src/components/DragList/DragList.js
+++ b/src/components/DragList/DragList.js
@@ -13,7 +13,7 @@ const StyledDiv = styled.div`
 
 /**
  * A list of items that can be dragged and reordered.
- * Use a list of [DragList.Item](/#!/DragListItem) as children.
+ * Use a list of [DragList.Item](#!/DragListItem) as children.
  * DragList.Container is provided
  * as a convenient way to display items in the drag list.
  */

--- a/src/components/DragList/DragListItem.js
+++ b/src/components/DragList/DragListItem.js
@@ -9,7 +9,7 @@ import { DragContext } from 'components/DragContainer';
  * Represents an item that can be dragged. Simply render a node inside of it that wraps the drag handle using
  * the `wrapDragHandle` prop automatically passed down by this component.
  *
- * [DragList.Container](/#!/DragContainer) can be used as an out of the box solution, but if a different component is required,
+ * [DragList.Container](#!/DragContainer) can be used as an out of the box solution, but if a different component is required,
  * you can use `DragList.Item.Consumer`, which uses the React context API.
  *
  * @visibleName DragList.Item

--- a/src/components/ToggleButton/ToggleButton.js
+++ b/src/components/ToggleButton/ToggleButton.js
@@ -7,7 +7,7 @@ import noop from 'lodash.noop';
 /**
  * `ToggleButton` is a simple styled button with some extra functionality built-in for handling selection. Control
  * it by setting `selected`, then use its `onClick` or `onSelect/onDeselect` handlers to implement selection or hook
- * into the [Selectable](/#!/Selectable) behavior. Set `name` to keep track of which button was pressed when a
+ * into the [Selectable](#!/Selectable) behavior. Set `name` to keep track of which button was pressed when a
  * click handler fires.
  */
 export default class ToggleButton extends React.PureComponent {

--- a/src/layouts/SplitContentLayout/SecondaryContent/styles/SidebarList/Item.js
+++ b/src/layouts/SplitContentLayout/SecondaryContent/styles/SidebarList/Item.js
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 import { ItemContainer, ItemLabel, ItemDetails } from './components';
 
 /**
- * An element of a [SidebarList](/#!/SidebarList).
+ * An element of a [SidebarList](#!/SidebarList).
  */
 export default class SidebarListItem extends React.PureComponent {
   static propTypes = {

--- a/src/layouts/SplitContentLayout/SecondaryContent/styles/SidebarList/index.js
+++ b/src/layouts/SplitContentLayout/SecondaryContent/styles/SidebarList/index.js
@@ -6,7 +6,7 @@ import Item from './Item';
 
 /**
  * Lays out items vertically in a sidebar. Does not handle scrolling.
- * Use [SidebarList.Item](/#!/SidebarListItem) as the child elements.
+ * Use [SidebarList.Item](#!/SidebarListItem) as the child elements.
  *
  * You can show selected state by either passing an `active` prop to the correct item
  * or linking your list to your router so that each item is a unique route. If you go that direction,


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props
- [x] Any extra props are spread into the outermost rendered element

Purely a docs change. Previously, the internal links only worked in the localhost environment. However, using `#!/` instead of `/#!` fixes the problem. For a comparison of current behavior, please visit http://dev.bandwidth.com/shared-components/#!/Layout and go to Data Presentation. Then click on the Field and Input links in the first paragraph. Field has the correct behavior, Input has the incorrect behavior.