### PR TITLE
BWDB-4523 UI - Date picker should open when the calendar icon is clicked

### DIFF
--- a/src/components/DatePicker/styles/overridesCss.js
+++ b/src/components/DatePicker/styles/overridesCss.js
@@ -65,6 +65,7 @@ export default css`
       font-family: var(--fonts-icon);
       font-size: 1.5em;
       transform: translateY(-50%);
+      pointer-events: none;
     }
     .DateInput_fang {
       display: none;


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [ ] Visual and behavioral components are separated
- [ ] Exported components are documented with examples
- [ ] Props have JSDoc comments
- [ ] All relevant visual sub-components can be overridden via props
- [ ] Any extra props are spread into the outermost rendered element

## Changes to Existing Components

Now '**DatePicker**' also opens when calendar icon is clicked