### PR TITLE
Fix searchable select initial value

### DIFF
--- a/src/components/Select/SearchableSelect.js
+++ b/src/components/Select/SearchableSelect.js
@@ -34,7 +34,7 @@ export default class SearchableSelect extends React.Component {
 
   state = {
     filteredOptions: this.props.options,
-    inputValue: '',
+    inputValue: undefined,
   };
 
   handleSelectStateChange = (changes, downshiftState) => {


### PR DESCRIPTION
## PR Checklist

Check these before submitting your pull request:

- [ ] Visual and behavioral components are separated
- [ ] Exported components are documented with examples
- [ ] Props have JSDoc comments
- [ ] All relevant visual sub-components can be overridden via props
- [ ] Any extra props are spread into the outermost rendered element

## Breaking Changes

There was an issue with the initial value of select. When you provide any `value` prop to `searchable select` it provides ‘’ (empty string) as value for the select, so the only thing you could see was default placeholder. But if you opened the select box and close it without select anything, it selected the provided value. The reason is that we provided `inputValue: '',` by default for `searchable select` and update this value only on change event. My solution is set `inputValue`  to `undefined` because it will use value instead of `inputValue`.
