### PR TITLE
Add disabled state for file loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14206,12 +14206,12 @@
       }
     },
     "react-dropzone": {
-      "version": "3.13.4",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-3.13.4.tgz",
-      "integrity": "sha1-hNomgVxAM5aRxJtFRMLvehaRLMw=",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-6.2.4.tgz",
+      "integrity": "sha512-fkG/Nxalhai12FdNw9RZ6dIr1SctmRXWekkSoOKAhNDAECwDg4HWKuvvZVkEAedGNeAgmkQRVoqNfT8uje1zfg==",
       "requires": {
-        "attr-accept": "^1.0.3",
-        "prop-types": "^15.5.7"
+        "attr-accept": "^1.1.3",
+        "prop-types": "^15.6.2"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-dates": "18.2.2",
     "react-dnd": "2.6.0",
     "react-dnd-html5-backend": "2.6.0",
-    "react-dropzone": "3.13.4",
+    "react-dropzone": "6.2.4",
     "react-motion": "0.5.2",
     "react-popper": "1.0.2",
     "react-select": "1.3.0",

--- a/src/components/FileLoader/FileLoader.js
+++ b/src/components/FileLoader/FileLoader.js
@@ -53,21 +53,23 @@ export default class FileLoader extends React.Component {
   };
 
   renderFiles = () => {
-    const { value, DropArea, Preview } = this.props;
+    const { value, DropArea, Preview, disabled } = this.props;
     if (value && value[0]) {
       return (
-        <DropArea>
+        <DropArea disabled={disabled}>
           <Icon name="fileFilled" />
           <Preview active={true}>{value[0].name}</Preview>
         </DropArea>
       );
     } else {
       return (
-        <DropArea>
+        <DropArea disabled={disabled}>
           <Icon name="file" />
           <Preview>
             DROP A FILE HERE, OR&nbsp;
-            <Link onClick={this.preventLinkClick}>CLICK TO BROWSE</Link>
+            <Link disabled={disabled} onClick={this.preventLinkClick}>
+              CLICK TO BROWSE
+            </Link>
           </Preview>
         </DropArea>
       );

--- a/src/components/Input/styles/InputStyles.js
+++ b/src/components/Input/styles/InputStyles.js
@@ -1,6 +1,13 @@
 import styled, { css } from 'styled-components';
 import get from 'extensions/themeGet';
 
+const disabledStyles = css`
+  background: ${get('colors.background.disabled')};
+  border-color: ${get('colors.border.disabled')};
+  opacity: 1;
+  color: ${get('colors.text.disabled')};
+`;
+
 const InputStyles = styled.input`
   letter-spacing: 0.02em;
   line-height: 1.5;
@@ -36,11 +43,10 @@ const InputStyles = styled.input`
   }
 
   &:disabled {
-    background: ${get('colors.background.disabled')};
-    border-color: ${get('colors.border.disabled')};
-    opacity: 1;
-    color: ${get('colors.text.disabled')};
+    ${disabledStyles}
   }
+
+  ${props => (props.disabled ? disabledStyles : '')}
 
   &::placeholder {
     opacity: 0.5;

--- a/src/components/Link/styles/TextLink.js
+++ b/src/components/Link/styles/TextLink.js
@@ -86,6 +86,12 @@ const TextLink = styled(Link)`
 
     ${({ appearFocused, icon }) =>
       appearFocused ? focusAfterStyles : icon ? 'opacity: 0;' : ''};
+
+    ${({ disabled }) =>
+      disabled &&
+      css`
+        background: ${get('colors.text.disabled')};
+      `}
   }
 
   &:hover::after,

--- a/stories/FileLoader.js
+++ b/stories/FileLoader.js
@@ -3,6 +3,8 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import FileLoader from 'components/FileLoader';
 
-storiesOf('FileLoader', module).add('types', () => (
-  <FileLoader onChange={action('fileUploaded')} />
-));
+storiesOf('FileLoader', module)
+  .add('types', () => <FileLoader onChange={action('fileUploaded')} />)
+  .add('disabled', () => (
+    <FileLoader onChange={action('fileUploaded')} disabled />
+  ));


### PR DESCRIPTION
## PR Checklist

![image](https://user-images.githubusercontent.com/2829772/52357701-99cb8b00-2a04-11e9-80f6-1b4f978395c0.png)


- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props
- [x] Any extra props are spread into the outermost rendered element

## Breaking Changes

* None

## Changes to Existing Components

* FileLoader disabled state was not functional. I updated the Dropzone library to support the `disabled` prop and fixed the styling.

## New Visual Components

* None

## New Behavioral Components

* None
