### PR TITLE
fix file loader text link preventing click

### DIFF
--- a/src/components/FileLoader/FileLoader.js
+++ b/src/components/FileLoader/FileLoader.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Dropzone from 'react-dropzone';
 import Icon from 'components/Icon';
-import Link from 'components/Link';
 import * as styles from './styles';
+import TextLink from 'components/Link/styles/TextLink';
 
 export default class FileLoader extends React.Component {
   static propTypes = {
@@ -48,10 +48,6 @@ export default class FileLoader extends React.Component {
 
   static styles = styles;
 
-  preventLinkClick = ev => {
-    ev.preventDefault();
-  };
-
   renderFiles = () => {
     const { value, error, disabled, DropArea, Preview } = this.props;
     if (value && value[0]) {
@@ -67,9 +63,13 @@ export default class FileLoader extends React.Component {
           <Icon name="file" />
           <Preview>
             DROP A FILE HERE, OR&nbsp;
-            <Link disabled={disabled} onClick={this.preventLinkClick}>
+            <TextLink
+              as="div"
+              style={{ display: 'inline-block' }}
+              disabled={disabled}
+            >
               CLICK TO BROWSE
-            </Link>
+            </TextLink>
           </Preview>
         </DropArea>
       );


### PR DESCRIPTION
![GIF](https://user-images.githubusercontent.com/2829772/54941876-49e94a80-4f04-11e9-883f-ff8f5f908605.gif)

## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props
- [x] Any extra props are spread into the outermost rendered element

## Breaking Changes

## Changes to Existing Components

* Switched Link component in FileLoader to use the TextLink styling component instead to avoid Link behaviors.

## New Visual Components

## New Behavioral Components

