### PR TITLE
Allow SplitContentLayout to omit Sidebar

### DIFF
--- a/docs/layoutsExample/Navigation.js
+++ b/docs/layoutsExample/Navigation.js
@@ -31,6 +31,9 @@ const SubNav = () => (
           <NavWrapLink to="/splitContent/leftComplex">
             <Navigation.Item>Left Complex</Navigation.Item>
           </NavWrapLink>
+          <NavWrapLink to="/splitContent/full">
+            <Navigation.Item>Full</Navigation.Item>
+          </NavWrapLink>
         </Navigation.ItemList>
       </Navigation.Sub>
     </Route>

--- a/docs/layoutsExample/demos/SplitContent/Full.js
+++ b/docs/layoutsExample/demos/SplitContent/Full.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {
+  SplitContentLayout,
+  H2,
+  Button,
+  Link,
+} from '@bandwidth/shared-components';
+import { Form, SidebarList, ActionBarExpandingContent } from '../widgets';
+
+export default () => (
+  <SplitContentLayout>
+    <SplitContentLayout.MainContent>
+      <H2>Content</H2>
+      <SplitContentLayout.MainContent.Box>
+        <Form columns={1}>
+          <SplitContentLayout.ActionBar
+            renderExpandingContent={params => (
+              <ActionBarExpandingContent {...params}>
+                <Form />
+                <br />
+                <Form />
+                <br />
+                <Form />
+                <br />
+                <Form />
+              </ActionBarExpandingContent>
+            )}
+          >
+            {({ toggleExpanded }) => (
+              <React.Fragment>
+                <Link onClick={toggleExpanded}>Show expanded</Link>
+                <Button>Submit</Button>
+              </React.Fragment>
+            )}
+          </SplitContentLayout.ActionBar>
+        </Form>
+      </SplitContentLayout.MainContent.Box>
+    </SplitContentLayout.MainContent>
+  </SplitContentLayout>
+);

--- a/docs/layoutsExample/demos/SplitContent/index.js
+++ b/docs/layoutsExample/demos/SplitContent/index.js
@@ -7,6 +7,7 @@ import LeftComplex from './LeftComplex';
 import Right from './Right';
 import RightComplex from './RightComplex';
 import Docs from './Docs';
+import Full from './Full';
 
 export default () => (
   <Switch>
@@ -15,5 +16,6 @@ export default () => (
     <Route exact path="/splitContent/rightComplex" component={RightComplex} />
     <Route exact path="/splitContent/left" component={Left} />
     <Route exact path="/splitContent/leftComplex" component={LeftComplex} />
+    <Route exact path="/splitContent/full" component={Full} />
   </Switch>
 );

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "styleguide": "cross-env NODE_PATH=src styleguidist server",
     "start": "npm run styleguide",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "layout": "webpack-serve docs/layouts/src/webpack.config.js",
+    "layout": "webpack-serve docs/layoutsExample/webpack.config.js",
     "build-docs:layouts": "webpack --config docs/layoutsExample/webpack.config.js --output-path docsDist/layouts",
     "build-docs:core": "cross-env NODE_PATH=src styleguidist build",
     "build-docs:v5": "cpy --parents --cwd=docs v5/**/* ../docsDist/",

--- a/src/layouts/SplitContentLayout/ActionBar/ActionBar.js
+++ b/src/layouts/SplitContentLayout/ActionBar/ActionBar.js
@@ -117,6 +117,7 @@ export default class ActionBar extends React.Component {
             <CSSTransition in={expanded} classNames="expand" timeout={200}>
               <Bar
                 mainContentLocation={layoutState.mainContentLocation}
+                secondaryContentPresent={layoutState.secondaryContentPresent}
                 actionBarLocation={layoutState.actionBarLocation}
               >
                 <PresenceNotifier

--- a/src/layouts/SplitContentLayout/ActionBar/styles/Bar.js
+++ b/src/layouts/SplitContentLayout/ActionBar/styles/Bar.js
@@ -7,10 +7,18 @@ const getExternalSpace = props =>
     ? `calc(${ONE_THIRD} - 1px)`
     : `calc(${TWO_THIRDS})`;
 
-const getLeftFromState = props =>
-  props.actionBarLocation === 'right' ? getExternalSpace(props) : '0';
-const getRightFromState = props =>
-  props.actionBarLocation === 'right' ? '0' : getExternalSpace(props);
+const getLeftFromState = props => {
+  if (!props.secondaryContentPresent) {
+    return '0';
+  }
+  return props.actionBarLocation === 'right' ? getExternalSpace(props) : '0';
+};
+const getRightFromState = props => {
+  if (!props.secondaryContentPresent) {
+    return '0';
+  }
+  return props.actionBarLocation === 'right' ? '0' : getExternalSpace(props);
+};
 
 export default styled.div`
   position: absolute;

--- a/src/layouts/SplitContentLayout/ActionBar/styles/ControlArea.js
+++ b/src/layouts/SplitContentLayout/ActionBar/styles/ControlArea.js
@@ -14,7 +14,9 @@ export default styled.div`
     justify-content: flex-start;
   }
 
-  & > * {
+  & > a,
+  & > div,
+  & > button {
     margin-top: auto;
     margin-bottom: auto;
     margin-right: ${themeGet('spacing.medium')};

--- a/src/layouts/SplitContentLayout/Context.js
+++ b/src/layouts/SplitContentLayout/Context.js
@@ -21,6 +21,12 @@ export class Provider extends React.PureComponent {
      */
     actionBarPresent: false,
     /**
+     * whether there is a SecondaryContent child mounted within the layout.
+     * this controls the size of the MainContent, which will expand to fill
+     * the whole area if SecondaryContent is not present.
+     */
+    secondaryContentPresent: false,
+    /**
      * A reference to the DOM element for the fixed layer which overlays
      * the main content area.
      */
@@ -129,6 +135,9 @@ export class Provider extends React.PureComponent {
   updateActionBarPresence = isPresent =>
     this.setState({ actionBarPresent: isPresent });
 
+  updateSecondaryContentPresence = isPresent =>
+    this.setState({ secondaryContentPresent: isPresent });
+
   /**
    * A master function for rendering components within the layout. This will
    * separate out sections which must be rendered in a 'fixed' layer and
@@ -155,6 +164,7 @@ export class Provider extends React.PureComponent {
         value={{
           ...this.state,
           updateActionBarPresence: this.updateActionBarPresence,
+          updateSecondaryContentPresence: this.updateSecondaryContentPresence,
           renderElement: this.renderElement,
         }}
       >

--- a/src/layouts/SplitContentLayout/MainContent/MainContent.js
+++ b/src/layouts/SplitContentLayout/MainContent/MainContent.js
@@ -16,6 +16,7 @@ const MainContent = ({ children, Container, ...rest }) => (
         'mainContent',
         <Container
           actionBarPresent={layoutContext.actionBarPresent}
+          secondaryContentPresent={layoutContext.secondaryContentPresent}
           actionBarLocation={layoutContext.actionBarLocation}
           mainContentLocation={layoutContext.mainContentLocation}
           {...rest}

--- a/src/layouts/SplitContentLayout/MainContent/styles/Container.js
+++ b/src/layouts/SplitContentLayout/MainContent/styles/Container.js
@@ -14,10 +14,18 @@ const getBottomSpaceFromState = props => {
   return themeGet('spacing.large')(props);
 };
 
-const getLeftFromState = props =>
-  props.mainContentLocation === 'left' ? '0' : ONE_THIRD;
-const getRightFromState = props =>
-  props.mainContentLocation === 'left' ? ONE_THIRD : '0';
+const getLeftFromState = props => {
+  if (!props.secondaryContentPresent) {
+    return '0';
+  }
+  return props.mainContentLocation === 'left' ? '0' : ONE_THIRD;
+};
+const getRightFromState = props => {
+  if (!props.secondaryContentPresent) {
+    return '0';
+  }
+  return props.mainContentLocation === 'left' ? ONE_THIRD : '0';
+};
 
 export default styled.div`
   position: relative;

--- a/src/layouts/SplitContentLayout/SecondaryContent/PresenceNotifier.js
+++ b/src/layouts/SplitContentLayout/SecondaryContent/PresenceNotifier.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default class SecondaryContentPresenceNotifier extends React.PureComponent {
+  componentDidMount() {
+    this.props.updateSecondaryContentPresence(true);
+  }
+  render() {
+    return null;
+  }
+}

--- a/src/layouts/SplitContentLayout/SecondaryContent/SecondaryContent.js
+++ b/src/layouts/SplitContentLayout/SecondaryContent/SecondaryContent.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { ScrollShadow } from 'behaviors';
 import * as styles from './styles';
 import { Consumer } from '../Context';
+import PresenceNotifier from './PresenceNotifier';
 
 /**
  * Secondary content is the 'sidebar'. In common configurations,
@@ -29,6 +30,11 @@ const SecondaryContent = ({
           overlapBorder={overlapBorder}
           {...rest}
         >
+          <PresenceNotifier
+            updateSecondaryContentPresence={
+              layoutContext.updateSecondaryContentPresence
+            }
+          />
           {children}
         </ScrollShadow>,
       )


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2829772/55490209-63278080-5601-11e9-98ab-b4b95bbbd8eb.png)

## PR Checklist

Check these before submitting your pull request:

- [x] Visual and behavioral components are separated
- [x] Exported components are documented with examples
- [x] Props have JSDoc comments
- [x] All relevant visual sub-components can be overridden via props
- [x] Any extra props are spread into the outermost rendered element

## Changes to Existing Components

* If you omit a `SecondaryContent`, SplitContentLayout will now make the MainContent take up the entire space.
