### PR TITLE
BWDB 4856 - update remote link so icon isn't obscured by subsequent text

### DIFF
--- a/src/components/Alert/styles/Border.js
+++ b/src/components/Alert/styles/Border.js
@@ -1,6 +1,7 @@
 import styled, { keyframes } from 'styled-components';
 import get from 'extensions/themeGet';
 import userSpacing from 'extensions/userSpacing';
+import TextLink from 'components/Link/styles/TextLink';
 
 const fadeIn = keyframes`
   from { opacity: 0; }
@@ -32,7 +33,7 @@ const AlertBorder = styled.div`
 
   background: ${getBgColorForType};
   
-  & a::before { background-color: ${getBgColorForType} !important;}
+  & ${TextLink}::before { background-color: ${getBgColorForType};}
   
   border-color: ${({ theme, type }) => {
     switch (type) {

--- a/src/components/Alert/styles/Border.js
+++ b/src/components/Alert/styles/Border.js
@@ -7,6 +7,17 @@ const fadeIn = keyframes`
   to { opacity: 1; }
 `;
 
+const getBgColorForType = ({ theme, type }) => {
+  switch (type) {
+    case 'success':
+      return get('colors.positive.light');
+    case 'error':
+      return get('colors.negative.light');
+    default:
+      return get('colors.primary.light');
+  }
+};
+
 const AlertBorder = styled.div`
   font-weight: 200;
   border-width: ${get('thicknesses.normal')};
@@ -19,17 +30,10 @@ const AlertBorder = styled.div`
   animation: ${fadeIn} 0.2s ease;
   transition: opacity 0.2s ease;
 
-  background: ${({ theme, type }) => {
-    switch (type) {
-      case 'success':
-        return get('colors.positive.light');
-      case 'error':
-        return get('colors.negative.light');
-      default:
-        return get('colors.primary.light');
-    }
-  }};
-
+  background: ${getBgColorForType};
+  
+  & a::before { background-color: ${getBgColorForType} !important;}
+  
   border-color: ${({ theme, type }) => {
     switch (type) {
       case 'success':

--- a/src/components/Link/styles/TextLink.js
+++ b/src/components/Link/styles/TextLink.js
@@ -15,6 +15,11 @@ const focusAfterStyles = css`
 const focusBeforeStyles = css`
   right: -1.5em;
   opacity: 1;
+  border-radius: 50%;
+  bottom: -0.1em;
+  top: -0.1em;
+  padding-left: 2px;
+  padding-right: 3px;
   transition: right 0.3s ease, opacity 0.2s ease 0.1s;
 `;
 

--- a/src/components/Link/styles/TextLink.js
+++ b/src/components/Link/styles/TextLink.js
@@ -13,12 +13,13 @@ const focusAfterStyles = css`
 `;
 
 const focusBeforeStyles = css`
-  right: -1.5em;
+  background-color: white;
+  right: -1.6em;
   opacity: 1;
   border-radius: 50%;
   bottom: -0.1em;
   top: -0.1em;
-  padding-left: 2px;
+  padding-left: 3px;
   padding-right: 3px;
   transition: right 0.3s ease, opacity 0.2s ease 0.1s;
 `;


### PR DESCRIPTION
## PR Checklist

If there is a child Link element pointing an external resource it has new tab icon fading in on hover.
This PR changes make that icon to overlap the element which goes close to the Link, for example text with a circled background white by default or derived from an Alert if out if put in Alert