### PR TITLE
allow passing props to input

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -97,6 +97,10 @@ class Select extends React.PureComponent {
      * underlying input element
      */
     inputProps: PropTypes.object,
+    /**
+     * Add a ref to the input element
+     */
+    inputRef: PropTypes.func,
   };
 
   static defaultProps = {
@@ -149,6 +153,7 @@ class Select extends React.PureComponent {
       name,
       autoComplete,
       inputProps,
+      inputRef,
       ...rest
     } = this.props;
     const combinedLoading = loading || isLoading;
@@ -181,6 +186,7 @@ class Select extends React.PureComponent {
                             ''
                       }
                       ref={ref}
+                      inputRef={inputRef}
                       placeholder={combinedPlaceholder}
                       disabled={disabled}
                       loading={combinedLoading}

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -92,6 +92,11 @@ class Select extends React.PureComponent {
      * code for details about how to implement your own custom version
      */
     Options: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    /**
+     * Any additional props you want to pass through CurrentValue to the
+     * underlying input element
+     */
+    inputProps: PropTypes.object,
   };
 
   static defaultProps = {
@@ -106,6 +111,7 @@ class Select extends React.PureComponent {
     defaultHighlightedIndex: 0,
     CurrentValue: styles.CurrentValue,
     Options: styles.Options,
+    inputProps: {},
   };
 
   static styles = styles;
@@ -142,6 +148,7 @@ class Select extends React.PureComponent {
       popperProps,
       name,
       autoComplete,
+      inputProps,
       ...rest
     } = this.props;
     const combinedLoading = loading || isLoading;
@@ -156,19 +163,22 @@ class Select extends React.PureComponent {
         {...rest}
       >
         {({ inputValue, ...downshiftProps }) => {
-          return ((
+          return (
             <div>
               <Manager>
                 <Reference>
                   {({ ref }) => (
                     <CurrentValue
                       {...downshiftProps}
+                      inputProps={inputProps}
                       inputValue={
                         downshiftProps.isOpen
                           ? inputValue
-                          : inputValue
-                            || downshiftProps.itemToString(downshiftProps.selectedItem)
-                            || ''
+                          : inputValue ||
+                            downshiftProps.itemToString(
+                              downshiftProps.selectedItem,
+                            ) ||
+                            ''
                       }
                       ref={ref}
                       placeholder={combinedPlaceholder}
@@ -190,7 +200,10 @@ class Select extends React.PureComponent {
                     modifiers={{
                       matchWidth: popperMatchWidthModifier,
                       flip: { behavior: 'flip', padding: 20 },
-                      preventOverflow: { escapeWithReference: true, padding: 0 },
+                      preventOverflow: {
+                        escapeWithReference: true,
+                        padding: 0,
+                      },
                     }}
                     {...popperProps}
                   >
@@ -211,7 +224,7 @@ class Select extends React.PureComponent {
                 )}
               </Manager>
             </div>
-          ))
+          );
         }}
       </Downshift>
     );

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -151,7 +151,6 @@ class Select extends React.PureComponent {
       className,
       popperProps,
       name,
-      autoComplete,
       inputProps,
       inputRef,
       ...rest
@@ -195,7 +194,6 @@ class Select extends React.PureComponent {
                       id={id}
                       className={className}
                       name={name}
-                      autoComplete={autoComplete}
                     />
                   )}
                 </Reference>

--- a/src/components/Select/Select.md
+++ b/src/components/Select/Select.md
@@ -169,3 +169,9 @@ const CustomizedSelect = props => (
   <Select Options={VirtualizedOptions} {...props} />
 );
 ```
+
+##### Example: Passing props to Input
+
+```js
+<Select inputProps={{ style: { background: 'red' }}} value="Food" options={['Foo', 'Bar']} />
+```

--- a/src/components/Select/styles/CurrentValue.js
+++ b/src/components/Select/styles/CurrentValue.js
@@ -76,6 +76,7 @@ const Unsearchable = forwardRef(
           appearFocused={isOpen}
           value={inputValue}
           ref={inputRef}
+          autoComplete="off"
           {...rest}
         />
         <Controls disabled={disabled}>

--- a/src/components/Select/styles/CurrentValue.js
+++ b/src/components/Select/styles/CurrentValue.js
@@ -47,6 +47,7 @@ const Unsearchable = forwardRef(
       ClearButton,
       Arrow,
       LoadingState,
+      inputProps,
       ...rest
     },
     ref,
@@ -65,19 +66,20 @@ const Unsearchable = forwardRef(
       >
         <Input
           role="select"
-          appearFocused={isOpen}
-          disabled={disabled}
           required={required}
-          invalid={invalid}
           placeholder={placeholder}
-          value={inputValue}
           hideCursor
+          invalid={invalid}
+          {...inputProps}
+          disabled={disabled}
+          appearFocused={isOpen}
+          value={inputValue}
           {...rest}
         />
         <Controls disabled={disabled}>
-          {!!inputValue &&
-            !disabled &&
-            !required && <ClearButton onClick={clearSelection} />}
+          {!!inputValue && !disabled && !required && (
+            <ClearButton onClick={clearSelection} />
+          )}
           <Arrow disabled={disabled} expanded={isOpen} />
         </Controls>
       </Wrapper>

--- a/src/components/Select/styles/CurrentValue.js
+++ b/src/components/Select/styles/CurrentValue.js
@@ -48,6 +48,7 @@ const Unsearchable = forwardRef(
       Arrow,
       LoadingState,
       inputProps,
+      inputRef,
       ...rest
     },
     ref,
@@ -74,6 +75,7 @@ const Unsearchable = forwardRef(
           disabled={disabled}
           appearFocused={isOpen}
           value={inputValue}
+          ref={inputRef}
           {...rest}
         />
         <Controls disabled={disabled}>

--- a/src/components/Select/styles/SearchableCurrentValue.js
+++ b/src/components/Select/styles/SearchableCurrentValue.js
@@ -63,6 +63,7 @@ const Searchable = forwardRef(
           value: inputValue,
         })}
         {...rest}
+        autoComplete="off"
         inlineContent={
           <Controls disabled={disabled}>
             {!!inputValue && !disabled && !required && (

--- a/src/components/Select/styles/SearchableCurrentValue.js
+++ b/src/components/Select/styles/SearchableCurrentValue.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import DefaultInput from 'components/Input';
 import DefaultLoadingState from './LoadingState';
 import DefaultControls from './Controls';
@@ -26,6 +26,7 @@ const Searchable = forwardRef(
       ClearButton,
       LoadingState,
       inputProps,
+      inputRef,
       ...rest
     },
     ref,
@@ -33,6 +34,18 @@ const Searchable = forwardRef(
     if (loading) {
       return <LoadingState required={required} invalid={invalid} />;
     }
+
+    // in the generally confusing landscape of our various implementations of Select,
+    // we somehow have ended up with two refs that need to point to the same element.
+    // The main ref for this component is for the Popper, but inputRef is for the
+    // user to utilize how they see fit.
+    const composedRefs = useCallback(
+      el => {
+        ref && ref(el);
+        inputRef && inputRef(el);
+      },
+      [ref, inputRef],
+    );
 
     return (
       <Input
@@ -43,7 +56,7 @@ const Searchable = forwardRef(
           invalid,
           ...inputProps,
           appearFocused: isOpen,
-          inputRef: ref,
+          inputRef: composedRefs,
           disabled: disabled || loading,
           onFocus: openMenu,
           onClick: openMenu,

--- a/src/components/Select/styles/SearchableCurrentValue.js
+++ b/src/components/Select/styles/SearchableCurrentValue.js
@@ -62,8 +62,8 @@ const Searchable = forwardRef(
           onClick: openMenu,
           value: inputValue,
         })}
-        {...rest}
         autoComplete="off"
+        {...rest}
         inlineContent={
           <Controls disabled={disabled}>
             {!!inputValue && !disabled && !required && (

--- a/src/components/Select/styles/SearchableCurrentValue.js
+++ b/src/components/Select/styles/SearchableCurrentValue.js
@@ -25,6 +25,7 @@ const Searchable = forwardRef(
       Arrow,
       ClearButton,
       LoadingState,
+      inputProps,
       ...rest
     },
     ref,
@@ -37,12 +38,13 @@ const Searchable = forwardRef(
       <Input
         visited={false}
         {...getInputProps({
-          inputRef: ref,
-          appearFocused: isOpen,
           placeholder,
-          disabled: disabled || loading,
           required,
           invalid,
+          ...inputProps,
+          appearFocused: isOpen,
+          inputRef: ref,
+          disabled: disabled || loading,
           onFocus: openMenu,
           onClick: openMenu,
           value: inputValue,
@@ -50,9 +52,9 @@ const Searchable = forwardRef(
         {...rest}
         inlineContent={
           <Controls disabled={disabled}>
-            {!!inputValue &&
-              !disabled &&
-              !required && <ClearButton onClick={clearSelection} />}
+            {!!inputValue && !disabled && !required && (
+              <ClearButton onClick={clearSelection} />
+            )}
             <Arrow
               disabled={disabled}
               {...getToggleButtonProps({


### PR DESCRIPTION
This has been on the radar for a while.

Lets you pass arbitrary props to the underlying Input in Select. So we can do `bw-id`, etc.

I'm also opening to just adding explicit `bw-id` support as a first-class prop, thoughts?